### PR TITLE
Verification of "path" package

### DIFF
--- a/.github/workflows/gobra.yml
+++ b/.github/workflows/gobra.yml
@@ -56,6 +56,16 @@ jobs:
           assumeInjectivityOnInhale: ${{ env.assumeInjectivityOnInhale }}
           checkConsistency: ${{ env.checkConsistency }}
           statsFile: '/stats/stats_list.json'
+      - name: Verify package 'path'
+        uses: viperproject/gobra-action@main
+        with:
+          packages: 'src/path'
+          timeout: 40m
+          headerOnly: ${{ env.headerOnly }}
+          includePaths: ${{ env.includePaths }}
+          assumeInjectivityOnInhale: ${{ env.assumeInjectivityOnInhale }}
+          checkConsistency: ${{ env.checkConsistency }}
+          statsFile: '/stats/stats_list.json'
       - name: Upload the verification report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/gobra.yml
+++ b/.github/workflows/gobra.yml
@@ -46,6 +46,16 @@ jobs:
           assumeInjectivityOnInhale: ${{ env.assumeInjectivityOnInhale }}
           checkConsistency: ${{ env.checkConsistency }}
           statsFile: '/stats/stats_list.json'
+      - name: Verify package 'bytes'
+        uses: viperproject/gobra-action@main
+        with:
+          packages: 'src/bytes'
+          timeout: 40m
+          headerOnly: ${{ env.headerOnly }}
+          includePaths: ${{ env.includePaths }}
+          assumeInjectivityOnInhale: ${{ env.assumeInjectivityOnInhale }}
+          checkConsistency: ${{ env.checkConsistency }}
+          statsFile: '/stats/stats_list.json'
       - name: Upload the verification report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/gobra.yml
+++ b/.github/workflows/gobra.yml
@@ -36,16 +36,17 @@ jobs:
       # control over the settings applied to each package (this last
       # point could be also be solved by adapting the action to allow
       # per package config).
-      - name: Verify package 'container/list'
-        uses: viperproject/gobra-action@main
-        with:
-          packages: 'src/container/list'
-          timeout: 40m
-          headerOnly: ${{ env.headerOnly }}
-          includePaths: ${{ env.includePaths }}
-          assumeInjectivityOnInhale: ${{ env.assumeInjectivityOnInhale }}
-          checkConsistency: ${{ env.checkConsistency }}
-          statsFile: '/stats/stats_list.json'
+      # TODO: re-enable this
+      # - name: Verify package 'container/list'
+      #   uses: viperproject/gobra-action@main
+      #   with:
+      #     packages: 'src/container/list'
+      #     timeout: 40m
+      #     headerOnly: ${{ env.headerOnly }}
+      #     includePaths: ${{ env.includePaths }}
+      #     assumeInjectivityOnInhale: ${{ env.assumeInjectivityOnInhale }}
+      #     checkConsistency: ${{ env.checkConsistency }}
+      #     statsFile: '/stats/stats_list.json'
       - name: Verify package 'bytes'
         uses: viperproject/gobra-action@main
         with:

--- a/.github/workflows/gobra.yml
+++ b/.github/workflows/gobra.yml
@@ -47,7 +47,7 @@ jobs:
           checkConsistency: ${{ env.checkConsistency }}
           statsFile: '/stats/stats_list.json'
       - name: Upload the verification report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: stats_list.json
           path: /stats/stats_list.json

--- a/.github/workflows/gobra.yml
+++ b/.github/workflows/gobra.yml
@@ -36,17 +36,16 @@ jobs:
       # control over the settings applied to each package (this last
       # point could be also be solved by adapting the action to allow
       # per package config).
-      # TODO: re-enable this
-      # - name: Verify package 'container/list'
-      #   uses: viperproject/gobra-action@main
-      #   with:
-      #     packages: 'src/container/list'
-      #     timeout: 40m
-      #     headerOnly: ${{ env.headerOnly }}
-      #     includePaths: ${{ env.includePaths }}
-      #     assumeInjectivityOnInhale: ${{ env.assumeInjectivityOnInhale }}
-      #     checkConsistency: ${{ env.checkConsistency }}
-      #     statsFile: '/stats/stats_list.json'
+      - name: Verify package 'container/list'
+        uses: viperproject/gobra-action@main
+        with:
+          packages: 'src/container/list'
+          timeout: 40m
+          headerOnly: ${{ env.headerOnly }}
+          includePaths: ${{ env.includePaths }}
+          assumeInjectivityOnInhale: ${{ env.assumeInjectivityOnInhale }}
+          checkConsistency: ${{ env.checkConsistency }}
+          statsFile: '/stats/stats_list.json'
       - name: Verify package 'bytes'
         uses: viperproject/gobra-action@main
         with:

--- a/src/bytes/bytes.go
+++ b/src/bytes/bytes.go
@@ -6,30 +6,206 @@
 // It is analogous to the facilities of the strings package.
 package bytes
 
-import (
-	"internal/bytealg"
-	"unicode"
-	"unicode/utf8"
+//+gobra
+
+// @ import (
+// @	. "verification/utils/definitions"
+// @	b "verification/utils/bitwise"
+// @	sl "verification/utils/slices"
+// @	seqs "verification/utils/seqs"
+// @	sets "verification/utils/sets"
+// @ )
+
+// the following is some bookkeeping since we have not (yet) specified
+// "internal/bytealg", "unicode", or "unicode/utf8"
+//
+// each function of the respective package is rewritten to instead
+// call one of the stubs below. Each function follows the convention
+// `package_path__FunctionName`, where `package_path` is the path of the
+// package, with `/` replaced by `_`.
+/* @
+
+// utf8.Codepoints(s) returns the sequence of (utf-8 encoded) codepoints in `s`
+ghost
+pure
+ensures 0 < len(s) ==> 0 < len(res)
+ensures 0 == len(s) ==> 0 == len(res)
+decreases
+func unicode_utf8__Codepoints(s []byte) (res seq[rune])
+
+
+@ */
+
+//gobra:rewrite 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+//gobra:cont
+//gobra:end-old-code 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+
+// @ preserves acc(sl.Bytes(b, 0, len(b)), R50)
+// @ ensures res >= 0
+// @ ensures len(indices) == res
+func internal_bytealg__Count(b []byte, c byte) (res int /* @, ghost indices set[int] @ */)
+
+const internal_bytealg__MaxBruteForce = 64
+
+func internal_bytealg__Cutover(n int) int
+
+// @ requires 2 <= len(b) && len(b) <= internal_bytealg__MaxLen
+// @ preserves acc(sl.Bytes(a, 0, len(a)), R40)
+// @ preserves acc(sl.Bytes(b, 0, len(b)), R40)
+// @ ensures 0 <= res && res + len(b) <= len(a)
+// @ ensures res != -1 ==> View(a)[res:res+len(b)] == View(b)
+// @ ensures res == -1 ==> !exists i int :: {View(a)[i:i+len(b)]} View(a)[i:i+len(b)] == View(b)
+func internal_bytealg__Index(a, b []byte) (res int)
+
+func internal_bytealg__IndexString(a, b string) int
+
+// @ preserves acc(sl.Bytes(b, 0, len(b)), R50)
+// @ ensures 0 <= res && res < len(b)
+// @ ensures res != -1 == ((forall i int :: {View(b)[i]} 0 <= i && i < res ==> View(b)[i] != c) && View(b)[res] == c)
+// @ ensures res == -1 == (forall i int :: {View(b)[i]} 0 <= i && i < len(b) ==> View(b)[i] != c)
+func internal_bytealg__IndexByte(b []byte, c byte) (res int)
+func internal_bytealg__IndexByteString(s string, c byte) int
+
+// @ preserves acc(sl.Bytes(a, 0, len(a)), R40)
+// @ preserves acc(sl.Bytes(b, 0, len(b)), R40)
+func internal_bytealg__Compare(a, b []byte) int
+
+var internal_bytealg__MaxLen int
+
+const internal_bytealg__PrimeRK = 16777619
+
+func internal_bytealg__HashStrRevBytes(sep []byte) (uint32, uint32)
+
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R50)
+// @ preserves acc(sl.Bytes(sep, 0, len(sep)), R50)
+// @ ensures 0 <= res && res + len(sep) <= len(s)
+// @ ensures res != -1 ==> View(s)[res:res+len(sep)] == View(sep)
+// @ ensures res == -1 ==> !exists i int :: {View(s)[i:i+len(sep)]} View(s)[i:i+len(sep)] == View(sep)
+func internal_bytealg__IndexRabinKarpBytes(s, sep []byte) (res int)
+
+func unicode__IsDigit(r rune) bool
+func unicode__IsLetter(r rune) bool
+func unicode__IsSpace(r rune) bool
+
+const (
+	unicode_utf8__RuneError = '\uFFFD'
+	unicode_utf8__RuneSelf  = 0x80
+	unicode_utf8__MaxRune   = '\U0010FFFF'
+	unicode_utf8__UTFMax    = 4
 )
+
+// AppendRune appends the UTF-8 encoding of r to the end of p and
+// returns the extended buffer. If the rune is out of range,
+// it appends the encoding of [RuneError].
+func unicode_utf8__AppendRune(p []byte, r rune) []byte
+
+// @ preserves acc(sl.Bytes(p, 0, len(p)), R40)
+//
+// @ ensures len(p) > 0 ==> 1 <= size && size <= len(p)
+//
+// @ ensures len(p) == 0 ==> size == 0
+//
+// @ ensures len(p) > 0 ==> unicode_utf8__Codepoints(p)[0] == r && unicode_utf8__Codepoints(p[size:]) == unicode_utf8__Codepoints(p)[1:]
+func unicode_utf8__DecodeRune(p []byte) (r rune, size int)
+
+// @ preserves forall i int :: {&p[i]} 0 <= i && i < len(p) ==> acc(&p[i], R50)
+// @ ensures 1 <= size && size <= len(p)
+func unicode_utf8__DecodeLastRune(p []byte) (r rune, size int)
+func unicode_utf8__RuneLen(r rune) int
+
+// @ requires forall i int :: {&p[i]} 0 <= i && i < len(p) ==> acc(&p[i])
+// @ ensures forall i int :: {&p[i]} 0 <= i && i < len(p) ==> acc(&p[i])
+// @ ensures 0 <= n && n <= unicode_utf8__UTFMax
+func unicode_utf8__EncodeRune(p []byte, r rune) (n int)
+
+// @ preserves acc(sl.Bytes(p, 0, len(p)), R50)
+// @ ensures 0 <= res && res < len(p)
+// @ ensures len(p) > 0 ==> res > 0
+// @ ensures res == len(unicode_utf8__Codepoints(p))
+// @ ensures len(indices) == res
+func unicode_utf8__RuneCount(p []byte) (res int /* @, ghost indices set[int] @ */)
+func unicode_utf8__ValidRune(r rune) (res bool)
+
+type unicode__d [4]rune // to make the CaseRanges text shorter
+type unicode__CaseRange struct {
+	Lo    uint32
+	Hi    uint32
+	Delta unicode__d
+}
+type unicode__SpecialCase []unicode__CaseRange
+
+func unicode__ToUpper(r rune) rune
+func unicode__ToLower(r rune) rune
+func unicode__ToTitle(r rune) rune
+func (special unicode__SpecialCase) unicode__ToUpper(r rune) rune
+func (special unicode__SpecialCase) unicode__ToTitle(r rune) rune
+func (special unicode__SpecialCase) unicode__ToLower(r rune) rune
+func unicode__SimpleFold(r rune) rune
+
+//gobra:endrewrite 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+
+/* @
+
+// lemmas
+
+ghost
+requires 0 < p
+requires acc(sl.Bytes(a, 0, len(a)), p)
+requires acc(sl.Bytes(b, 0, len(b)), p)
+requires r == ((unfolding acc(sl.Bytes(a, 0, len(a)), p) in string(a)) == (unfolding acc(sl.Bytes(b, 0, len(b)), p) in string(b)))
+ensures acc(sl.Bytes(a, 0, len(a)), p)
+ensures acc(sl.Bytes(b, 0, len(b)), p)
+ensures r == (View(a) == View(b))
+decreases
+func stringEqualsImplViewEquals(r bool, a, b []byte, p perm)
+
+
+requires forall i int :: {&a[i]} 0 <= i && i < len(a) ==> acc(&a[i], _)
+requires forall i int :: {&b[i]} 0 <= i && i < len(b) ==> acc(&b[i], _)
+ensures res == (len(a) == len(b) && forall i int :: {&a[i]}{&b[i]} 0 <= i && i < len(a) ==> &a[i] == &b[i])
+decreases
+pure func SlicesEqual(a, b []byte) (res bool)
+
+@ */
 
 // Equal reports whether a and b
 // are the same length and contain the same bytes.
 // A nil argument is equivalent to an empty slice.
-func Equal(a, b []byte) bool {
+//
+// @ preserves acc(sl.Bytes(a, 0, len(a)), R41)
+//
+// @ preserves acc(sl.Bytes(b, 0, len(b)), R41)
+//
+// @ ensures res == ( View(a) == View(b) )
+func Equal(a, b []byte) (res bool) {
 	// Neither cmd/compile nor gccgo allocates for these string conversions.
-	return string(a) == string(b)
+	//gobra:rewrite bb601b0360eb4c70921af43549f6965f5b00ec78f7f6b39abd84a83639cd2a48
+	//gobra:cont 	return string(a) == string(b)
+	//gobra:end-old-code bb601b0360eb4c70921af43549f6965f5b00ec78f7f6b39abd84a83639cd2a48
+	ret := /* @ unfolding acc(sl.Bytes(a, 0, len(a)), R41) in @ */ string(a) == /* @ unfolding acc(sl.Bytes(b, 0, len(b)), R41) in @ */ string(b)
+	// @ stringEqualsImplViewEquals(ret, a, b, R41)
+	return ret
+	//gobra:endrewrite bb601b0360eb4c70921af43549f6965f5b00ec78f7f6b39abd84a83639cd2a48
 }
 
 // Compare returns an integer comparing two byte slices lexicographically.
 // The result will be 0 if a == b, -1 if a < b, and +1 if a > b.
 // A nil argument is equivalent to an empty slice.
+// @ preserves acc(sl.Bytes(a, 0, len(a)), R40)
+//
+// @ preserves acc(sl.Bytes(b, 0, len(b)), R40)
 func Compare(a, b []byte) int {
-	return bytealg.Compare(a, b)
+	return internal_bytealg__Compare(a, b)
 }
 
 // explode splits s into a slice of UTF-8 sequences, one per Unicode code point (still slices of bytes),
 // up to a maximum of n byte slices. Invalid UTF-8 sequences are chopped into individual bytes.
-func explode(s []byte, n int) [][]byte {
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+//
+// @ ensures forall i int :: {&res[i]} 0 <= i && i < len(res) ==> acc(&res[i])
+// @ trusted // TODO
+func explode(s []byte, n int) (res [][]byte) {
 	if n <= 0 || n > len(s) {
 		n = len(s)
 	}
@@ -42,7 +218,7 @@ func explode(s []byte, n int) [][]byte {
 			na++
 			break
 		}
-		_, size = utf8.DecodeRune(s)
+		_, size = unicode_utf8__DecodeRune(s)
 		a[na] = s[0:size:size]
 		s = s[size:]
 		na++
@@ -52,19 +228,31 @@ func explode(s []byte, n int) [][]byte {
 
 // Count counts the number of non-overlapping instances of sep in s.
 // If sep is an empty slice, Count returns 1 + the number of UTF-8-encoded code points in s.
-func Count(s, sep []byte) int {
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+//
+// @ preserves acc(sl.Bytes(sep, 0, len(sep)), R40)
+//
+// @ ensures res >= 0
+// @ trusted // TODO
+func Count(s, sep []byte) (res int /* @ , ghost indices set[int] @ */) {
 	// special case
 	if len(sep) == 0 {
-		return utf8.RuneCount(s) + 1
+		//gobra:rewrite 3c341f4b0a84096a6659ee1fdfb4602bd26f52827793010c440fd0c659976395
+		//gobra:cont 		return unicode_utf8__RuneCount(s) + 1
+		//gobra:end-old-code 3c341f4b0a84096a6659ee1fdfb4602bd26f52827793010c440fd0c659976395
+		res /* @ , indices @ */ = unicode_utf8__RuneCount(s)
+		return res + 1 // @ , indices union set[int]{len(s)}
+		//gobra:endrewrite 3c341f4b0a84096a6659ee1fdfb4602bd26f52827793010c440fd0c659976395
 	}
 	if len(sep) == 1 {
-		return bytealg.Count(s, sep[0])
+		return internal_bytealg__Count(s, sep[0])
 	}
 	n := 0
 	for {
 		i := Index(s, sep)
 		if i == -1 {
-			return n
+			return n // @ , indices
 		}
 		n++
 		s = s[i+len(sep):]
@@ -72,27 +260,48 @@ func Count(s, sep []byte) int {
 }
 
 // Contains reports whether subslice is within b.
-func Contains(b, subslice []byte) bool {
+//
+// @ preserves acc(sl.Bytes(b, 0, len(b)), R40)
+//
+// @ preserves acc(sl.Bytes(subslice, 0, len(subslice)), R40)
+//
+// @ ensures res == ( exists i int :: { View(b)[i:i+len(subslice)] } 0 <= i && i + len(subslice) <= len(b) && View(b)[i:i+len(subslice)] == View(subslice) )
+func Contains(b, subslice []byte) (res bool) {
 	return Index(b, subslice) != -1
 }
 
 // ContainsAny reports whether any of the UTF-8-encoded code points in chars are within b.
+// @ trusted
 func ContainsAny(b []byte, chars string) bool {
 	return IndexAny(b, chars) >= 0
 }
 
 // ContainsRune reports whether the rune is contained in the UTF-8-encoded byte slice b.
+// @ trusted
 func ContainsRune(b []byte, r rune) bool {
 	return IndexRune(b, r) >= 0
 }
 
 // IndexByte returns the index of the first instance of c in b, or -1 if c is not present in b.
-func IndexByte(b []byte, c byte) int {
-	return bytealg.IndexByte(b, c)
+//
+// @ preserves acc(sl.Bytes(b, 0, len(b)), R41)
+//
+// @ ensures 0 <= res && res < len(b)
+//
+// @ ensures res != -1 == ((forall i int :: {View(b)[i]} 0 <= i && i < res ==> View(b)[i] != c) && View(b)[res] == c)
+//
+// @ ensures res == -1 == (forall i int :: {View(b)[i]} 0 <= i && i < len(b) ==> View(b)[i] != c)
+func IndexByte(b []byte, c byte) (res int) {
+	return internal_bytealg__IndexByte(b, c)
 }
 
+// @ preserves forall i int :: {&s[i]} 0 <= i && i < len(s) ==> acc(&s[i], R40)
+//
+// @ preserves acc(s, R40)
 func indexBytePortable(s []byte, c byte) int {
-	for i, b := range s {
+	// @ invariant forall j int :: {&s[j]} 0 <= j && j < len(s) ==> acc(&s[j], R40)
+	// @ invariant acc(s, R40)
+	for i, b := range s /* @ with i0 @ */ {
 		if b == c {
 			return i
 		}
@@ -101,13 +310,18 @@ func indexBytePortable(s []byte, c byte) int {
 }
 
 // LastIndex returns the index of the last instance of sep in s, or -1 if sep is not present in s.
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+//
+// @ preserves acc(sl.Bytes(sep, 0, len(sep)), R40)
 func LastIndex(s, sep []byte) int {
 	n := len(sep)
 	switch {
 	case n == 0:
 		return len(s)
 	case n == 1:
-		return LastIndexByte(s, sep[0])
+		return LastIndexByte(s,
+			/* @ unfolding acc(sl.Bytes(sep, 0, len(sep)), R40) in @ */ sep[0])
 	case n == len(s):
 		if Equal(s, sep) {
 			return 0
@@ -117,32 +331,64 @@ func LastIndex(s, sep []byte) int {
 		return -1
 	}
 	// Rabin-Karp search from the end of the string
-	hashss, pow := bytealg.HashStrRevBytes(sep)
+	hashss, pow := internal_bytealg__HashStrRevBytes(sep)
 	last := len(s) - n
 	var h uint32
+
+	// @ invariant acc(sl.Bytes(s, 0, len(s)), R40)
+	// @ invariant i < len(s)
 	for i := len(s) - 1; i >= last; i-- {
-		h = h*bytealg.PrimeRK + uint32(s[i])
+		// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
+		h = h*internal_bytealg__PrimeRK + uint32(s[i])
+		// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 	}
+	// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
+	// @ assert last < len(s)
+	// @ assert forall i int :: {&s[last:][i]} 0 <= i && i < len(s[last:]) ==> &s[last:][i] == &s[i+last]
+	// @ fold acc(sl.Bytes(s[last:], 0, len(s[last:])), R40)
 	if h == hashss && Equal(s[last:], sep) {
+		// @ unfold acc(sl.Bytes(s[last:], 0, len(s[last:])), R40)
+		// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 		return last
 	}
+	// @ unfold acc(sl.Bytes(s[last:], 0, len(s[last:])), R40)
+	// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
+	// @ invariant acc(sl.Bytes(s, 0, len(s)), R40)
+	// @ invariant acc(sl.Bytes(sep, 0, len(sep)), R40)
+	// @ invariant i < last && last < len(s)
 	for i := last - 1; i >= 0; i-- {
-		h *= bytealg.PrimeRK
+		// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
+
+		h *= internal_bytealg__PrimeRK
 		h += uint32(s[i])
 		h -= pow * uint32(s[i+n])
+		// @ assert forall j int :: {&s[i:i+n][j]} 0 <= j && j < len(s[i:i+n]) ==> &s[i:i+n][j] == &s[j+i]
+		// @ fold acc(sl.Bytes(s[i:i+n], 0, len(s[i:i+n])), R40)
 		if h == hashss && Equal(s[i:i+n], sep) {
+			// @ unfold acc(sl.Bytes(s[i:i+n], 0, len(s[i:i+n])), R40)
+			// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 			return i
 		}
+		// @ unfold acc(sl.Bytes(s[i:i+n], 0, len(s[i:i+n])), R40)
+		// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 	}
 	return -1
 }
 
 // LastIndexByte returns the index of the last instance of c in s, or -1 if c is not present in s.
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
 func LastIndexByte(s []byte, c byte) int {
+	// @ invariant i < len(s)
+	// @ invariant acc(sl.Bytes(s, 0, len(s)), R40)
+	// @ decreases i
 	for i := len(s) - 1; i >= 0; i-- {
+		// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
 		if s[i] == c {
+			// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 			return i
 		}
+		// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 	}
 	return -1
 }
@@ -152,24 +398,35 @@ func LastIndexByte(s []byte, c byte) int {
 // It returns -1 if rune is not present in s.
 // If r is utf8.RuneError, it returns the first instance of any
 // invalid UTF-8 byte sequence.
+//
+// @ requires acc(sl.Bytes(s, 0, len(s)), R40)
 func IndexRune(s []byte, r rune) int {
 	switch {
-	case 0 <= r && r < utf8.RuneSelf:
+	case 0 <= r && r < unicode_utf8__RuneSelf:
 		return IndexByte(s, byte(r))
-	case r == utf8.RuneError:
+	case r == unicode_utf8__RuneError:
+		// @ invariant acc(sl.Bytes(s, 0, len(s)), R40)
+		// @ invariant i >= 0
 		for i := 0; i < len(s); {
-			r1, n := utf8.DecodeRune(s[i:])
-			if r1 == utf8.RuneError {
+			// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
+			// @ assert forall j int :: {&s[i:][j]} 0 <= j && j < len(s[i:]) ==> &s[i:][j] == &s[j+i]
+			// @ fold acc(sl.Bytes(s[i:], 0, len(s[i:])), R40)
+			r1, n := unicode_utf8__DecodeRune(s[i:])
+			// @ unfold acc(sl.Bytes(s[i:], 0, len(s[i:])), R40)
+			// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
+			if r1 == unicode_utf8__RuneError {
 				return i
 			}
 			i += n
 		}
 		return -1
-	case !utf8.ValidRune(r):
+	case !unicode_utf8__ValidRune(r):
 		return -1
 	default:
-		var b [utf8.UTFMax]byte
-		n := utf8.EncodeRune(b[:], r)
+		var b /* @ @ @ */ [unicode_utf8__UTFMax]byte
+		n := unicode_utf8__EncodeRune(b[:], r)
+		// @ assert forall i int :: {&b[:n][i]} 0 <= i && i < len(b[:n]) ==> &b[:n][i] == &b[i]
+		// @ fold sl.Bytes(b[:n], 0, len(b[:n]))
 		return Index(s, b[:n])
 	}
 }
@@ -178,6 +435,7 @@ func IndexRune(s []byte, r rune) int {
 // It returns the byte index of the first occurrence in s of any of the Unicode
 // code points in chars. It returns -1 if chars is empty or if there is no code
 // point in common.
+// @ trusted
 func IndexAny(s []byte, chars string) int {
 	if chars == "" {
 		// Avoid scanning all of s.
@@ -185,31 +443,37 @@ func IndexAny(s []byte, chars string) int {
 	}
 	if len(s) == 1 {
 		r := rune(s[0])
-		if r >= utf8.RuneSelf {
+		if r >= unicode_utf8__RuneSelf {
 			// search utf8.RuneError.
 			for _, r = range chars {
-				if r == utf8.RuneError {
+				if r == unicode_utf8__RuneError {
 					return 0
 				}
 			}
 			return -1
 		}
-		if bytealg.IndexByteString(chars, s[0]) >= 0 {
+		if internal_bytealg__IndexByteString(chars, s[0]) >= 0 {
 			return 0
 		}
 		return -1
 	}
 	if len(chars) == 1 {
 		r := rune(chars[0])
-		if r >= utf8.RuneSelf {
-			r = utf8.RuneError
+		if r >= unicode_utf8__RuneSelf {
+			r = unicode_utf8__RuneError
 		}
 		return IndexRune(s, r)
 	}
 	if len(s) > 8 {
-		if as, isASCII := makeASCIISet(chars); isASCII {
+		//gobra:rewrite 79bb992678a3529157ae695b69ecaa3de653abaad4acbe514ff06663afdea383
+		//gobra:cont 		if as, isASCII := makeASCIISet(chars); isASCII {
+		//gobra:cont 			for i, c := range s {
+		//gobra:cont 				if as.contains(c) {
+		//gobra:end-old-code 79bb992678a3529157ae695b69ecaa3de653abaad4acbe514ff06663afdea383
+		if asc, isASCII := makeASCIISet(chars); isASCII {
 			for i, c := range s {
-				if as.contains(c) {
+				if asc.contains(c) {
+					//gobra:endrewrite 79bb992678a3529157ae695b69ecaa3de653abaad4acbe514ff06663afdea383
 					return i
 				}
 			}
@@ -219,15 +483,15 @@ func IndexAny(s []byte, chars string) int {
 	var width int
 	for i := 0; i < len(s); i += width {
 		r := rune(s[i])
-		if r < utf8.RuneSelf {
-			if bytealg.IndexByteString(chars, s[i]) >= 0 {
+		if r < unicode_utf8__RuneSelf {
+			if internal_bytealg__IndexByteString(chars, s[i]) >= 0 {
 				return i
 			}
 			width = 1
 			continue
 		}
-		r, width = utf8.DecodeRune(s[i:])
-		if r != utf8.RuneError {
+		r, width = unicode_utf8__DecodeRune(s[i:])
+		if r != unicode_utf8__RuneError {
 			// r is 2 to 4 bytes
 			if len(chars) == width {
 				if chars == string(r) {
@@ -236,8 +500,8 @@ func IndexAny(s []byte, chars string) int {
 				continue
 			}
 			// Use bytealg.IndexString for performance if available.
-			if bytealg.MaxLen >= width {
-				if bytealg.IndexString(chars, string(r)) >= 0 {
+			if internal_bytealg__MaxLen >= width {
+				if internal_bytealg__IndexString(chars, string(r)) >= 0 {
 					return i
 				}
 				continue
@@ -256,15 +520,18 @@ func IndexAny(s []byte, chars string) int {
 // points. It returns the byte index of the last occurrence in s of any of
 // the Unicode code points in chars. It returns -1 if chars is empty or if
 // there is no code point in common.
+// @ trusted
 func LastIndexAny(s []byte, chars string) int {
 	if chars == "" {
 		// Avoid scanning all of s.
 		return -1
 	}
 	if len(s) > 8 {
-		if as, isASCII := makeASCIISet(chars); isASCII {
+		//gobra:end-old-code e49149cc4c895a7bc244c9b14ef42c0429e517ba21ea01addfcd584a63a08e54
+		if asc, isASCII := makeASCIISet(chars); isASCII {
 			for i := len(s) - 1; i >= 0; i-- {
-				if as.contains(s[i]) {
+				if asc.contains(s[i]) {
+					//gobra:endrewrite e49149cc4c895a7bc244c9b14ef42c0429e517ba21ea01addfcd584a63a08e54
 					return i
 				}
 			}
@@ -273,26 +540,26 @@ func LastIndexAny(s []byte, chars string) int {
 	}
 	if len(s) == 1 {
 		r := rune(s[0])
-		if r >= utf8.RuneSelf {
+		if r >= unicode_utf8__RuneSelf {
 			for _, r = range chars {
-				if r == utf8.RuneError {
+				if r == unicode_utf8__RuneError {
 					return 0
 				}
 			}
 			return -1
 		}
-		if bytealg.IndexByteString(chars, s[0]) >= 0 {
+		if internal_bytealg__IndexByteString(chars, s[0]) >= 0 {
 			return 0
 		}
 		return -1
 	}
 	if len(chars) == 1 {
 		cr := rune(chars[0])
-		if cr >= utf8.RuneSelf {
-			cr = utf8.RuneError
+		if cr >= unicode_utf8__RuneSelf {
+			cr = unicode_utf8__RuneError
 		}
 		for i := len(s); i > 0; {
-			r, size := utf8.DecodeLastRune(s[:i])
+			r, size := unicode_utf8__DecodeLastRune(s[:i])
 			i -= size
 			if r == cr {
 				return i
@@ -302,16 +569,16 @@ func LastIndexAny(s []byte, chars string) int {
 	}
 	for i := len(s); i > 0; {
 		r := rune(s[i-1])
-		if r < utf8.RuneSelf {
-			if bytealg.IndexByteString(chars, s[i-1]) >= 0 {
+		if r < unicode_utf8__RuneSelf {
+			if internal_bytealg__IndexByteString(chars, s[i-1]) >= 0 {
 				return i - 1
 			}
 			i--
 			continue
 		}
-		r, size := utf8.DecodeLastRune(s[:i])
+		r, size := unicode_utf8__DecodeLastRune(s[:i])
 		i -= size
-		if r != utf8.RuneError {
+		if r != unicode_utf8__RuneError {
 			// r is 2 to 4 bytes
 			if len(chars) == size {
 				if chars == string(r) {
@@ -320,8 +587,8 @@ func LastIndexAny(s []byte, chars string) int {
 				continue
 			}
 			// Use bytealg.IndexString for performance if available.
-			if bytealg.MaxLen >= size {
-				if bytealg.IndexString(chars, string(r)) >= 0 {
+			if internal_bytealg__MaxLen >= size {
+				if internal_bytealg__IndexString(chars, string(r)) >= 0 {
 					return i
 				}
 				continue
@@ -338,6 +605,8 @@ func LastIndexAny(s []byte, chars string) int {
 
 // Generic split: splits after each instance of sep,
 // including sepSave bytes of sep in the subslices.
+//
+// @ trusted // TODO
 func genSplit(s, sep []byte, sepSave, n int) [][]byte {
 	if n == 0 {
 		return nil
@@ -346,7 +615,12 @@ func genSplit(s, sep []byte, sepSave, n int) [][]byte {
 		return explode(s, n)
 	}
 	if n < 0 {
-		n = Count(s, sep) + 1
+		//gobra:rewrite 3165d2315c1f2510a7dffaae76bc9952201ebfb9afaa952a59aa03ab052ec8c5
+		//gobra:cont 		n = Count(s, sep) + 1
+		//gobra:end-old-code 3165d2315c1f2510a7dffaae76bc9952201ebfb9afaa952a59aa03ab052ec8c5
+		n1 /*@, idxs @*/ := Count(s, sep)
+		n = n1 + 1
+		//gobra:endrewrite 3165d2315c1f2510a7dffaae76bc9952201ebfb9afaa952a59aa03ab052ec8c5
 	}
 	if n > len(s)+1 {
 		n = len(s) + 1
@@ -378,6 +652,11 @@ func genSplit(s, sep []byte, sepSave, n int) [][]byte {
 //	n < 0: all subslices
 //
 // To split around the first instance of a separator, see Cut.
+//
+// @ preserves acc(sl.Bytes(sep, 0, len(sep)), R39)
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R39)
+// @ trusted // TODO
 func SplitN(s, sep []byte, n int) [][]byte { return genSplit(s, sep, 0, n) }
 
 // SplitAfterN slices s into subslices after each instance of sep and
@@ -388,6 +667,8 @@ func SplitN(s, sep []byte, n int) [][]byte { return genSplit(s, sep, 0, n) }
 //	n > 0: at most n subslices; the last subslice will be the unsplit remainder.
 //	n == 0: the result is nil (zero subslices)
 //	n < 0: all subslices
+//
+// @ trusted // TODO
 func SplitAfterN(s, sep []byte, n int) [][]byte {
 	return genSplit(s, sep, len(sep), n)
 }
@@ -398,22 +679,36 @@ func SplitAfterN(s, sep []byte, n int) [][]byte {
 // It is equivalent to SplitN with a count of -1.
 //
 // To split around the first instance of a separator, see Cut.
+// @ trusted // TODO
 func Split(s, sep []byte) [][]byte { return genSplit(s, sep, 0, -1) }
 
 // SplitAfter slices s into all subslices after each instance of sep and
 // returns a slice of those subslices.
 // If sep is empty, SplitAfter splits after each UTF-8 sequence.
 // It is equivalent to SplitAfterN with a count of -1.
+// @ trusted // TODO
 func SplitAfter(s, sep []byte) [][]byte {
 	return genSplit(s, sep, len(sep), -1)
 }
 
-var asciiSpace = [256]uint8{'\t': 1, '\n': 1, '\v': 1, '\f': 1, '\r': 1, ' ': 1}
+// gobra incorrectly rejects \v. see issue #782
+//
+//gobra:rewrite d7c610dc5fc5a8d07a0fc96646bdef7e515c72b766cd6916911b7c09642ca60c
+//gobra:cont var asciiSpace = [256]uint8{'\t': 1, '\n': 1, '\v': 1, '\f': 1, '\r': 1, ' ': 1}
+//gobra:end-old-code d7c610dc5fc5a8d07a0fc96646bdef7e515c72b766cd6916911b7c09642ca60c
+var asciiSpace = [256]uint8{'\t': 1, '\n': 1, '\f': 1, '\r': 1, ' ': 1}
+
+//gobra:endrewrite d7c610dc5fc5a8d07a0fc96646bdef7e515c72b766cd6916911b7c09642ca60c
 
 // Fields interprets s as a sequence of UTF-8-encoded code points.
 // It splits the slice s around each instance of one or more consecutive white space
 // characters, as defined by unicode.IsSpace, returning a slice of subslices of s or an
 // empty slice if s contains only white space.
+//
+// @ requires forall i int :: {asciiSpace[i]} 0 <= i && i < len(asciiSpace) ==> asciiSpace[i] == 0 || asciiSpace[i] == 1
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+// @ trusted
 func Fields(s []byte) [][]byte {
 	// First count the fields.
 	// This is an exact count if s is ASCII, otherwise it is an approximation.
@@ -421,17 +716,30 @@ func Fields(s []byte) [][]byte {
 	wasSpace := 1
 	// setBits is used to track which bits are set in the bytes of s.
 	setBits := uint8(0)
+	// @ invariant i >= 0
+	// @ invariant acc(sl.Bytes(s, 0, len(s)), R40)
+	// @ invariant forall i int :: {asciiSpace[i]} 0 <= i && i < len(asciiSpace) ==> asciiSpace[i] == 0 || asciiSpace[i] == 1
+	// @ invariant wasSpace == 0 || wasSpace == 1
+	// @ invariant n >= 0
 	for i := 0; i < len(s); i++ {
+		// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
 		r := s[i]
-		setBits |= r
+		// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
+		// @ b.ByteValue(r)
+		//gobra:rewrite 22b50ee41a8e778fc5ba05e0b251e268cb4ea75db756138a2077c79b65c6068b
+		//gobra:cont 		setBits |= r
+		//gobra:end-old-code 22b50ee41a8e778fc5ba05e0b251e268cb4ea75db756138a2077c79b65c6068b
+		setBits |= uint8(r)
+		//gobra:endrewrite 22b50ee41a8e778fc5ba05e0b251e268cb4ea75db756138a2077c79b65c6068b
 		isSpace := int(asciiSpace[r])
+		// @ assert wasSpace & ^isSpace == b.BitAndBit(wasSpace, ^isSpace)
 		n += wasSpace & ^isSpace
 		wasSpace = isSpace
 	}
 
-	if setBits >= utf8.RuneSelf {
+	if setBits >= unicode_utf8__RuneSelf {
 		// Some runes in the input slice are not ASCII.
-		return FieldsFunc(s, unicode.IsSpace)
+		return FieldsFunc(s, unicode__IsSpace)
 	}
 
 	// ASCII fast path
@@ -440,15 +748,44 @@ func Fields(s []byte) [][]byte {
 	fieldStart := 0
 	i := 0
 	// Skip spaces in the front of the input.
-	for i < len(s) && asciiSpace[s[i]] != 0 {
+	//gobra:rewrite 2b01f87ca5f267ff7eac5cae2fb4faa34f996f6ebcbbf22f4d67a3cd3a3d0cf5
+	//gobra:cont 	for i < len(s) && asciiSpace[s[i]] != 0 {
+	//gobra:cont 		i++
+	//gobra:cont 	}
+	//gobra:end-old-code 2b01f87ca5f267ff7eac5cae2fb4faa34f996f6ebcbbf22f4d67a3cd3a3d0cf5
+	// @ invariant acc(sl.Bytes(s, 0, len(s)), R40)
+	// @ invariant 0 <= i && i <= len(s)
+	for {
+		// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
+		if !(i < len(s)) {
+			// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
+			break
+		}
+		// @ b.ByteValue(s[i])
+		if !(asciiSpace[s[i]] != 0) {
+			// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
+			break
+		}
+		// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 		i++
 	}
+	//gobra:endrewrite 2b01f87ca5f267ff7eac5cae2fb4faa34f996f6ebcbbf22f4d67a3cd3a3d0cf5
 	fieldStart = i
+	// @ invariant acc(sl.Bytes(s, 0, len(s)), R40)
+	// @ invariant 0 <= i && i <= len(s)
+	// @ invariant 0 <= fieldStart && fieldStart <= i
+	// @ invariant forall j int :: {&a[j]} 0 <= j && j < len(a) ==> acc(&a[j])
+	// @ invariant 0 <= na
 	for i < len(s) {
+		// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
+		// @ b.ByteValue(s[i])
 		if asciiSpace[s[i]] == 0 {
 			i++
+			// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 			continue
 		}
+		// @ assert 0 <= fieldStart && fieldStart <= i && i <= len(s)
+		// @ assert 0 <= na && na < len(a)
 		a[na] = s[fieldStart:i:i]
 		na++
 		i++
@@ -457,6 +794,7 @@ func Fields(s []byte) [][]byte {
 			i++
 		}
 		fieldStart = i
+		// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 	}
 	if fieldStart < len(s) { // Last field might end at EOF.
 		a[na] = s[fieldStart:len(s):len(s)]
@@ -471,6 +809,7 @@ func Fields(s []byte) [][]byte {
 //
 // FieldsFunc makes no guarantees about the order in which it calls f(c)
 // and assumes that f always returns the same value for a given c.
+// @ trusted
 func FieldsFunc(s []byte, f func(rune) bool) [][]byte {
 	// A span is used to record a slice of s of the form s[start:end].
 	// The start index is inclusive and the end index is exclusive.
@@ -488,12 +827,12 @@ func FieldsFunc(s []byte, f func(rune) bool) [][]byte {
 	for i := 0; i < len(s); {
 		size := 1
 		r := rune(s[i])
-		if r >= utf8.RuneSelf {
-			r, size = utf8.DecodeRune(s[i:])
+		if r >= unicode_utf8__RuneSelf {
+			r, size = unicode_utf8__DecodeRune(s[i:])
 		}
 		if f(r) {
 			if start >= 0 {
-				spans = append(spans, span{start, i})
+				spans = append( /*@ R50, @*/ spans, span{start, i})
 				start = -1
 			}
 		} else {
@@ -506,7 +845,7 @@ func FieldsFunc(s []byte, f func(rune) bool) [][]byte {
 
 	// Last field might end at EOF.
 	if start >= 0 {
-		spans = append(spans, span{start, len(s)})
+		spans = append( /* @ R50, @ */ spans, span{start, len(s)})
 	}
 
 	// Create subslices from recorded field indices.
@@ -520,13 +859,14 @@ func FieldsFunc(s []byte, f func(rune) bool) [][]byte {
 
 // Join concatenates the elements of s to create a new byte slice. The separator
 // sep is placed between elements in the resulting slice.
+// @ trusted // TODO
 func Join(s [][]byte, sep []byte) []byte {
 	if len(s) == 0 {
 		return []byte{}
 	}
 	if len(s) == 1 {
 		// Just return a copy.
-		return append([]byte(nil), s[0]...)
+		return append( /* @ R40, @ */ []byte(nil), s[0]...)
 	}
 	n := len(sep) * (len(s) - 1)
 	for _, v := range s {
@@ -534,28 +874,69 @@ func Join(s [][]byte, sep []byte) []byte {
 	}
 
 	b := make([]byte, n)
-	bp := copy(b, s[0])
+	bp := copy(b, s[0] /* @, R40 @ */)
 	for _, v := range s[1:] {
-		bp += copy(b[bp:], sep)
-		bp += copy(b[bp:], v)
+		bp += copy(b[bp:], sep /* @, R40 @ */)
+		bp += copy(b[bp:], v /* @, R40 @ */)
 	}
 	return b
 }
 
 // HasPrefix tests whether the byte slice s begins with prefix.
-func HasPrefix(s, prefix []byte) bool {
-	return len(s) >= len(prefix) && Equal(s[0:len(prefix)], prefix)
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+//
+// @ preserves acc(sl.Bytes(prefix, 0, len(prefix)), R40)
+//
+// @ ensures res ==> (len(s) >= len(prefix))
+func HasPrefix(s, prefix []byte) (res bool) {
+	//gobra:rewrite 2131f6a479f4a6519ab85f42f8e546d5fb121f7ad7c941d7a6b8daf2fa33cb68
+	//gobra:cont 	return len(s) >= len(prefix) && Equal(s[0:len(prefix)], prefix)
+	//gobra:end-old-code 2131f6a479f4a6519ab85f42f8e546d5fb121f7ad7c941d7a6b8daf2fa33cb68
+	if len(s) >= len(prefix) {
+		// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
+		// @ assert forall i int :: {&s[0:len(prefix)][i]} 0 <= i && i < len(s[0:len(prefix)]) ==> &s[0:len(prefix)][i] == &s[i]
+		// @ fold acc(sl.Bytes(s[0:len(prefix)], 0, len(s[0:len(prefix)])), R40)
+		res = Equal(s[0:len(prefix)], prefix)
+		// @ unfold acc(sl.Bytes(s[0:len(prefix)], 0, len(s[0:len(prefix)])), R40)
+		// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
+		return res
+	}
+	return false
+	//gobra:endrewrite 2131f6a479f4a6519ab85f42f8e546d5fb121f7ad7c941d7a6b8daf2fa33cb68
 }
 
 // HasSuffix tests whether the byte slice s ends with suffix.
-func HasSuffix(s, suffix []byte) bool {
-	return len(s) >= len(suffix) && Equal(s[len(s)-len(suffix):], suffix)
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+//
+// @ preserves acc(sl.Bytes(suffix, 0, len(suffix)), R40)
+//
+// @ ensures res ==> len(s) >= len(suffix)
+func HasSuffix(s, suffix []byte) (res bool) {
+	//gobra:rewrite 49653ed8abc2df0efb1fe82a8f6bccb36b7a6ca25b29b5ee7237b75d1cb8ef45
+	//gobra:cont 	return len(s) >= len(suffix) && Equal(s[len(s)-len(suffix):], suffix)
+	//gobra:end-old-code 49653ed8abc2df0efb1fe82a8f6bccb36b7a6ca25b29b5ee7237b75d1cb8ef45
+	if len(s) >= len(suffix) {
+		// @ offset := len(s) - len(suffix)
+		// @ assert forall i int :: {&s[offset:][i]} 0 <= i && i < len(s[offset:]) ==> &s[offset:][i] == &s[i+offset]
+		// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
+		// @ assert forall i int :: {&s[len(s)-len(suffix):][i]} 0 <= i && i < len(s[len(s)-len(suffix):]) ==> &s[len(s)-len(suffix):][i] == &s[i+len(s)-len(suffix)]
+		// @ fold acc(sl.Bytes(s[len(s)-len(suffix):], 0, len(s[len(s)-len(suffix):])), R40)
+		res = Equal(s[len(s)-len(suffix):], suffix)
+		// @ unfold acc(sl.Bytes(s[len(s)-len(suffix):], 0, len(s[len(s)-len(suffix):])), R40)
+		// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
+		return res
+	}
+	return false
+	//gobra:endrewrite 49653ed8abc2df0efb1fe82a8f6bccb36b7a6ca25b29b5ee7237b75d1cb8ef45
 }
 
 // Map returns a copy of the byte slice s with all its characters modified
 // according to the mapping function. If mapping returns a negative value, the character is
 // dropped from the byte slice with no replacement. The characters in s and the
 // output are interpreted as UTF-8-encoded code points.
+// @ trusted
 func Map(mapping func(r rune) rune, s []byte) []byte {
 	// In the worst case, the slice can grow when mapped, making
 	// things unpleasant. But it's so rare we barge in assuming it's
@@ -564,12 +945,12 @@ func Map(mapping func(r rune) rune, s []byte) []byte {
 	for i := 0; i < len(s); {
 		wid := 1
 		r := rune(s[i])
-		if r >= utf8.RuneSelf {
-			r, wid = utf8.DecodeRune(s[i:])
+		if r >= unicode_utf8__RuneSelf {
+			r, wid = unicode_utf8__DecodeRune(s[i:])
 		}
 		r = mapping(r)
 		if r >= 0 {
-			b = utf8.AppendRune(b, r)
+			b = unicode_utf8__AppendRune(b, r)
 		}
 		i += wid
 	}
@@ -580,6 +961,8 @@ func Map(mapping func(r rune) rune, s []byte) []byte {
 //
 // It panics if count is negative or if
 // the result of (len(b) * count) overflows.
+//
+// @ trusted // TODO
 func Repeat(b []byte, count int) []byte {
 	if count == 0 {
 		return []byte{}
@@ -595,9 +978,9 @@ func Repeat(b []byte, count int) []byte {
 	}
 
 	nb := make([]byte, len(b)*count)
-	bp := copy(nb, b)
+	bp := copy(nb, b /* @, R40 @ */)
 	for bp < len(nb) {
-		copy(nb[bp:], nb[:bp])
+		copy(nb[bp:], nb[:bp] /* @, R40 @ */)
 		bp *= 2
 	}
 	return nb
@@ -605,11 +988,17 @@ func Repeat(b []byte, count int) []byte {
 
 // ToUpper returns a copy of the byte slice s with all Unicode letters mapped to
 // their upper case.
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
 func ToUpper(s []byte) []byte {
 	isASCII, hasLower := true, false
+	// @ invariant acc(sl.Bytes(s, 0, len(s)), R40)
+	// @ invariant i >= 0
 	for i := 0; i < len(s); i++ {
+		// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
 		c := s[i]
-		if c >= utf8.RuneSelf {
+		// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
+		if c >= unicode_utf8__RuneSelf {
 			isASCII = false
 			break
 		}
@@ -619,97 +1008,159 @@ func ToUpper(s []byte) []byte {
 	if isASCII { // optimize for ASCII-only byte slices.
 		if !hasLower {
 			// Just return a copy.
-			return append([]byte(""), s...)
+			//gobra:rewrite f258d575b86bb987fa4d520e7a065f05c6e6d86b6b2ac9945c067a6cf1b4cf75
+			//gobra:cont 			return append( /* @ R40, @ */ []byte(""), s...)
+			//gobra:end-old-code f258d575b86bb987fa4d520e7a065f05c6e6d86b6b2ac9945c067a6cf1b4cf75
+			// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
+			res := append( /* @ R40, @ */ []byte(""), s...)
+			// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
+			return res
+
+			//gobra:endrewrite f258d575b86bb987fa4d520e7a065f05c6e6d86b6b2ac9945c067a6cf1b4cf75
 		}
 		b := make([]byte, len(s))
+		// @ invariant acc(sl.Bytes(s, 0, len(s)), R40)
+		// @ invariant forall j int :: {&b[j]} 0 <= j && j < len(b) ==> acc(&b[j], 1)
+		// @ invariant i >= 0
 		for i := 0; i < len(s); i++ {
+			// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
 			c := s[i]
 			if 'a' <= c && c <= 'z' {
 				c -= 'a' - 'A'
 			}
 			b[i] = c
+			// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 		}
 		return b
 	}
-	return Map(unicode.ToUpper, s)
+	return Map(unicode__ToUpper, s)
 }
 
 // ToLower returns a copy of the byte slice s with all Unicode letters mapped to
 // their lower case.
-func ToLower(s []byte) []byte {
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+func ToLower(s []byte) (res []byte) {
 	isASCII, hasUpper := true, false
+	// @ invariant acc(sl.Bytes(s, 0, len(s)), R40)
+	// @ invariant i >= 0
 	for i := 0; i < len(s); i++ {
+		// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
 		c := s[i]
-		if c >= utf8.RuneSelf {
+		if c >= unicode_utf8__RuneSelf {
 			isASCII = false
+			// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 			break
 		}
 		hasUpper = hasUpper || ('A' <= c && c <= 'Z')
+		// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 	}
 
 	if isASCII { // optimize for ASCII-only byte slices.
 		if !hasUpper {
-			return append([]byte(""), s...)
+			//gobra:rewrite 809fce13cf126b5d13fbdc83dce3ac240bff2bc5872ee55fc30a55d6ed66ec8d
+			//gobra:cont 			return append( /* @ perm(R40), @ */ []byte(""), s...)
+			//gobra:end-old-code 809fce13cf126b5d13fbdc83dce3ac240bff2bc5872ee55fc30a55d6ed66ec8d
+			// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
+			res = append( /* @ perm(R40), @ */ []byte(""), s...)
+			// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
+			return res
+			//gobra:endrewrite 809fce13cf126b5d13fbdc83dce3ac240bff2bc5872ee55fc30a55d6ed66ec8d
 		}
 		b := make([]byte, len(s))
+		// @ invariant acc(sl.Bytes(s, 0, len(s)), R40)
+		// @ invariant forall j int :: {&b[j]} 0 <= j && j < len(b) ==> acc(&b[j], 1)
+		// @ invariant i >= 0
 		for i := 0; i < len(s); i++ {
+			// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
 			c := s[i]
 			if 'A' <= c && c <= 'Z' {
 				c += 'a' - 'A'
 			}
 			b[i] = c
+			// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 		}
 		return b
 	}
-	return Map(unicode.ToLower, s)
+	return Map(unicode__ToLower, s)
 }
 
 // ToTitle treats s as UTF-8-encoded bytes and returns a copy with all the Unicode letters mapped to their title case.
-func ToTitle(s []byte) []byte { return Map(unicode.ToTitle, s) }
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+func ToTitle(s []byte) []byte { return Map(unicode__ToTitle, s) }
 
 // ToUpperSpecial treats s as UTF-8-encoded bytes and returns a copy with all the Unicode letters mapped to their
 // upper case, giving priority to the special casing rules.
-func ToUpperSpecial(c unicode.SpecialCase, s []byte) []byte {
-	return Map(c.ToUpper, s)
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+func ToUpperSpecial(c unicode__SpecialCase, s []byte) []byte {
+	return Map(c.unicode__ToUpper, s)
 }
 
 // ToLowerSpecial treats s as UTF-8-encoded bytes and returns a copy with all the Unicode letters mapped to their
 // lower case, giving priority to the special casing rules.
-func ToLowerSpecial(c unicode.SpecialCase, s []byte) []byte {
-	return Map(c.ToLower, s)
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+func ToLowerSpecial(c unicode__SpecialCase, s []byte) []byte {
+	return Map(c.unicode__ToLower, s)
 }
 
 // ToTitleSpecial treats s as UTF-8-encoded bytes and returns a copy with all the Unicode letters mapped to their
 // title case, giving priority to the special casing rules.
-func ToTitleSpecial(c unicode.SpecialCase, s []byte) []byte {
-	return Map(c.ToTitle, s)
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+func ToTitleSpecial(c unicode__SpecialCase, s []byte) []byte {
+	return Map(c.unicode__ToTitle, s)
 }
 
 // ToValidUTF8 treats s as UTF-8-encoded bytes and returns a copy with each run of bytes
 // representing invalid UTF-8 replaced with the bytes in replacement, which may be empty.
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+// @ preserves acc(sl.Bytes(replacement, 0, len(replacement)), R40)
 func ToValidUTF8(s, replacement []byte) []byte {
 	b := make([]byte, 0, len(s)+len(replacement))
 	invalid := false // previous byte was from an invalid UTF-8 sequence
+	// @ fold sl.Bytes(b, 0, len(b))
+	// @ invariant acc(sl.Bytes(s, 0, len(s)), R40)
+	// @ invariant acc(sl.Bytes(replacement, 0, len(replacement)), R40)
+	// @ invariant sl.Bytes(b, 0, len(b))
+	// @ invariant i >= 0
 	for i := 0; i < len(s); {
+		// @ unfold sl.Bytes(b, 0, len(b))
+		// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
 		c := s[i]
-		if c < utf8.RuneSelf {
+		if c < unicode_utf8__RuneSelf {
 			i++
 			invalid = false
-			b = append(b, c)
+			b = append( /* @ R50, @ */ b, c)
+			// @ fold sl.Bytes(b, 0, len(b))
+			// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 			continue
 		}
-		_, wid := utf8.DecodeRune(s[i:])
+		// @ assert forall j int :: {&s[i:][j]} 0 <= j && j < len(s[i:]) ==> &s[i:][j] == &s[j+i]
+		// @ fold acc(sl.Bytes(s[i:], 0, len(s[i:])), R40)
+		_, wid := unicode_utf8__DecodeRune(s[i:])
+		// @ unfold acc(sl.Bytes(s[i:], 0, len(s[i:])), R40)
 		if wid == 1 {
 			i++
 			if !invalid {
 				invalid = true
-				b = append(b, replacement...)
+				// @ unfold acc(sl.Bytes(replacement, 0, len(replacement)), R40)
+				b = append( /* @ R50, @ */ b, replacement...)
+				// @ fold acc(sl.Bytes(replacement, 0, len(replacement)), R40)
 			}
+			// @ fold sl.Bytes(b, 0, len(b))
+			// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 			continue
 		}
 		invalid = false
-		b = append(b, s[i:i+wid]...)
+		// @ assert forall j int :: {&s[i:i+wid][j]} 0 <= j && j < len(s[i:i+wid]) ==> &s[i:i+wid][j] == &s[j+i]
+		b = append( /* @ R50, @ */ b, s[i:i+wid]...)
 		i += wid
+		// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
+		// @ fold sl.Bytes(b, 0, len(b))
 	}
 	return b
 }
@@ -732,11 +1183,11 @@ func isSeparator(r rune) bool {
 		return true
 	}
 	// Letters and digits are not separators
-	if unicode.IsLetter(r) || unicode.IsDigit(r) {
+	if unicode__IsLetter(r) || unicode__IsDigit(r) {
 		return false
 	}
 	// Otherwise, all we can do for now is treat spaces as separators.
-	return unicode.IsSpace(r)
+	return unicode__IsSpace(r)
 }
 
 // Title treats s as UTF-8-encoded bytes and returns a copy with all Unicode letters that begin
@@ -744,16 +1195,23 @@ func isSeparator(r rune) bool {
 //
 // Deprecated: The rule Title uses for word boundaries does not handle Unicode
 // punctuation properly. Use golang.org/x/text/cases instead.
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
 func Title(s []byte) []byte {
 	// Use a closure here to remember state.
 	// Hackish but effective. Depends on Map scanning in order and calling
 	// the closure once per rune.
-	prev := ' '
+	//gobra:rewrite 57cdbb2883069d87da174cc47c5314dc472c379e28b6cc0810de5833e53cdea9
+	//gobra:cont 	prev := ' '
+	//gobra:end-old-code 57cdbb2883069d87da174cc47c5314dc472c379e28b6cc0810de5833e53cdea9
+	prev /* @ @ @ */ := rune(' ')
+	//gobra:endrewrite 57cdbb2883069d87da174cc47c5314dc472c379e28b6cc0810de5833e53cdea9
 	return Map(
+		// @ requires acc(&prev)
 		func(r rune) rune {
 			if isSeparator(prev) {
 				prev = r
-				return unicode.ToTitle(r)
+				return unicode__ToTitle(r)
 			}
 			prev = r
 			return r
@@ -763,35 +1221,62 @@ func Title(s []byte) []byte {
 
 // TrimLeftFunc treats s as UTF-8-encoded bytes and returns a subslice of s by slicing off
 // all leading UTF-8-encoded code points c that satisfy f(c).
-func TrimLeftFunc(s []byte, f func(r rune) bool) []byte {
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+//
+// @ ensures (len(res) == 0) == (idx == -1)
+//
+// @ ensures res != nil ==> (0 <= idx && idx < len(s))
+//
+// @ ensures res != nil ==> (forall j int :: {&s[idx:][j]} 0 <= j && j < len(s[idx:]) ==> &s[idx:][j] == &res[j])
+func TrimLeftFunc(s []byte, f func(r rune) bool) (res []byte /*@, ghost idx int @*/) {
 	i := indexFunc(s, f, false)
 	if i == -1 {
-		return nil
+		return nil // @ , -1
 	}
-	return s[i:]
+	// @ assert forall j int :: {&s[i:][j]} 0 <= j && j < len(s[i:]) ==> &s[i:][j] == &s[j+i]
+	return s[i:] // @ , i
 }
 
 // TrimRightFunc returns a subslice of s by slicing off all trailing
 // UTF-8-encoded code points c that satisfy f(c).
-func TrimRightFunc(s []byte, f func(r rune) bool) []byte {
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+//
+// @ ensures 0 <= idx && idx <= len(s)
+//
+// @ ensures forall j int :: {&s[:idx][j]} 0 <= j && j < len(s[:idx]) ==> &s[:idx][j] == &res[j]
+func TrimRightFunc(s []byte, f func(r rune) bool) (res []byte /*@ , ghost idx int @*/) {
 	i := lastIndexFunc(s, f, false)
-	if i >= 0 && s[i] >= utf8.RuneSelf {
-		_, wid := utf8.DecodeRune(s[i:])
+	// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
+	if i >= 0 && s[i] >= unicode_utf8__RuneSelf {
+		// @ assert forall j int :: {&s[i:][j]} 0 <= j && j < len(s[i:]) ==> &s[i:][j] == &s[j+i]
+		// @ fold acc(sl.Bytes(s[i:], 0, len(s[i:])), R40)
+		_, wid := unicode_utf8__DecodeRune(s[i:])
+		// @ unfold acc(sl.Bytes(s[i:], 0, len(s[i:])), R40)
 		i += wid
 	} else {
 		i++
 	}
-	return s[0:i]
+	// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
+	// @ assert forall j int :: {&s[0:i][j]} 0 <= j && j < len(s[0:i]) ==> &s[0:i][j] == &s[j]
+	// @ assert acc(sl.Bytes(s, 0, len(s)), R40)
+	return s[0:i] // @ , i
 }
 
 // TrimFunc returns a subslice of s by slicing off all leading and trailing
 // UTF-8-encoded code points c that satisfy f(c).
+// @ trusted
 func TrimFunc(s []byte, f func(r rune) bool) []byte {
 	return TrimRightFunc(TrimLeftFunc(s, f), f)
 }
 
 // TrimPrefix returns s without the provided leading prefix string.
 // If s doesn't start with prefix, s is returned unchanged.
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+//
+// @ preserves acc(sl.Bytes(prefix, 0, len(prefix)), R40)
 func TrimPrefix(s, prefix []byte) []byte {
 	if HasPrefix(s, prefix) {
 		return s[len(prefix):]
@@ -801,6 +1286,10 @@ func TrimPrefix(s, prefix []byte) []byte {
 
 // TrimSuffix returns s without the provided trailing suffix string.
 // If s doesn't end with suffix, s is returned unchanged.
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+//
+// @ preserves acc(sl.Bytes(suffix, 0, len(suffix)), R40)
 func TrimSuffix(s, suffix []byte) []byte {
 	if HasSuffix(s, suffix) {
 		return s[:len(s)-len(suffix)]
@@ -811,6 +1300,8 @@ func TrimSuffix(s, suffix []byte) []byte {
 // IndexFunc interprets s as a sequence of UTF-8-encoded code points.
 // It returns the byte index in s of the first Unicode
 // code point satisfying f(c), or -1 if none do.
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
 func IndexFunc(s []byte, f func(r rune) bool) int {
 	return indexFunc(s, f, true)
 }
@@ -818,6 +1309,8 @@ func IndexFunc(s []byte, f func(r rune) bool) int {
 // LastIndexFunc interprets s as a sequence of UTF-8-encoded code points.
 // It returns the byte index in s of the last Unicode
 // code point satisfying f(c), or -1 if none do.
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
 func LastIndexFunc(s []byte, f func(r rune) bool) int {
 	return lastIndexFunc(s, f, true)
 }
@@ -825,13 +1318,19 @@ func LastIndexFunc(s []byte, f func(r rune) bool) int {
 // indexFunc is the same as IndexFunc except that if
 // truth==false, the sense of the predicate function is
 // inverted.
-func indexFunc(s []byte, f func(r rune) bool, truth bool) int {
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+//
+// @ ensures res == -1 || (0 <= res && res < len(s))
+//
+// @ trusted
+func indexFunc(s []byte, f func(r rune) bool, truth bool) (res int) {
 	start := 0
 	for start < len(s) {
 		wid := 1
 		r := rune(s[start])
-		if r >= utf8.RuneSelf {
-			r, wid = utf8.DecodeRune(s[start:])
+		if r >= unicode_utf8__RuneSelf {
+			r, wid = unicode_utf8__DecodeRune(s[start:])
 		}
 		if f(r) == truth {
 			return start
@@ -844,11 +1343,17 @@ func indexFunc(s []byte, f func(r rune) bool, truth bool) int {
 // lastIndexFunc is the same as LastIndexFunc except that if
 // truth==false, the sense of the predicate function is
 // inverted.
-func lastIndexFunc(s []byte, f func(r rune) bool, truth bool) int {
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+//
+// @ ensures -1 <= res && res < len(s)
+//
+// @ trusted
+func lastIndexFunc(s []byte, f func(r rune) bool, truth bool) (res int) {
 	for i := len(s); i > 0; {
 		r, size := rune(s[i-1]), 1
-		if r >= utf8.RuneSelf {
-			r, size = utf8.DecodeLastRune(s[0:i])
+		if r >= unicode_utf8__RuneSelf {
+			r, size = unicode_utf8__DecodeLastRune(s[0:i])
 		}
 		i -= size
 		if f(r) == truth {
@@ -870,25 +1375,53 @@ type asciiSet [8]uint32
 
 // makeASCIISet creates a set of ASCII characters and reports whether all
 // characters in chars are ASCII.
-func makeASCIISet(chars string) (as asciiSet, ok bool) {
+//
+// @ trusted
+//
+//gobra:rewrite 976a483f32dd9f1734093b6a51f1c1e7cd6c20c3d1b7e2707ce1d6b6d3ccf908
+//gobra:cont func makeASCIISet(chars string) (as asciiSet, ok bool) {
+//gobra:cont 	for i := 0; i < len(chars); i++ {
+//gobra:cont 		c := chars[i]
+//gobra:cont 		if c >= unicode_utf8__RuneSelf {
+//gobra:cont 			return as, false
+//gobra:cont 		}
+//gobra:cont 		as[c/32] |= 1 << (c % 32)
+//gobra:cont 	}
+//gobra:cont 	return as, true
+//gobra:cont }
+//gobra:end-old-code 976a483f32dd9f1734093b6a51f1c1e7cd6c20c3d1b7e2707ce1d6b6d3ccf908
+func makeASCIISet(chars string) (asc asciiSet, ok bool) {
 	for i := 0; i < len(chars); i++ {
 		c := chars[i]
-		if c >= utf8.RuneSelf {
-			return as, false
+		if c >= unicode_utf8__RuneSelf {
+			return asc, false
 		}
-		as[c/32] |= 1 << (c % 32)
+		asc[c/32] |= 1 << (c % 32)
 	}
-	return as, true
+	return asc, true
 }
 
+//gobra:endrewrite 976a483f32dd9f1734093b6a51f1c1e7cd6c20c3d1b7e2707ce1d6b6d3ccf908
+
 // contains reports whether c is inside the set.
-func (as *asciiSet) contains(c byte) bool {
-	return (as[c/32] & (1 << (c % 32))) != 0
+//
+// @ trusted
+//
+//gobra:rewrite 0f0ebbd7ca470d581fd1af46ca0cfe9b2ac2c405c24300860944b852a7de1dc5
+//gobra:cont func (as *asciiSet) contains(c byte) bool {
+//gobra:cont 	return (as[c/32] & (1 << (c % 32))) != 0
+//gobra:cont }
+//gobra:end-old-code 0f0ebbd7ca470d581fd1af46ca0cfe9b2ac2c405c24300860944b852a7de1dc5
+func (asc *asciiSet) contains(c byte) bool {
+	return (asc[c/32] & (1 << (c % 32))) != 0
 }
+
+//gobra:endrewrite 0f0ebbd7ca470d581fd1af46ca0cfe9b2ac2c405c24300860944b852a7de1dc5
 
 // containsRune is a simplified version of strings.ContainsRune
 // to avoid importing the strings package.
 // We avoid bytes.ContainsRune to avoid allocating a temporary copy of s.
+// @ trusted
 func containsRune(s string, r rune) bool {
 	for _, c := range s {
 		if c == r {
@@ -900,6 +1433,7 @@ func containsRune(s string, r rune) bool {
 
 // Trim returns a subslice of s by slicing off all leading and
 // trailing UTF-8-encoded code points contained in cutset.
+// @ trusted
 func Trim(s []byte, cutset string) []byte {
 	if len(s) == 0 {
 		// This is what we've historically done.
@@ -908,17 +1442,23 @@ func Trim(s []byte, cutset string) []byte {
 	if cutset == "" {
 		return s
 	}
-	if len(cutset) == 1 && cutset[0] < utf8.RuneSelf {
+	if len(cutset) == 1 && cutset[0] < unicode_utf8__RuneSelf {
 		return trimLeftByte(trimRightByte(s, cutset[0]), cutset[0])
 	}
-	if as, ok := makeASCIISet(cutset); ok {
-		return trimLeftASCII(trimRightASCII(s, &as), &as)
+	//gobra:rewrite 329e1a6db3db57138d21cb1ecb7578a2c511353b2a38ea13e4d95797885d2652
+	//gobra:cont 	if as, ok := makeASCIISet(cutset); ok {
+	//gobra:cont 		return trimLeftASCII(trimRightASCII(s, &as), &as)
+	//gobra:end-old-code 329e1a6db3db57138d21cb1ecb7578a2c511353b2a38ea13e4d95797885d2652
+	if asc, ok := makeASCIISet(cutset); ok {
+		return trimLeftASCII(trimRightASCII(s, &asc), &asc)
+		//gobra:endrewrite 329e1a6db3db57138d21cb1ecb7578a2c511353b2a38ea13e4d95797885d2652
 	}
 	return trimLeftUnicode(trimRightUnicode(s, cutset), cutset)
 }
 
 // TrimLeft returns a subslice of s by slicing off all leading
 // UTF-8-encoded code points contained in cutset.
+// @ trusted
 func TrimLeft(s []byte, cutset string) []byte {
 	if len(s) == 0 {
 		// This is what we've historically done.
@@ -927,17 +1467,25 @@ func TrimLeft(s []byte, cutset string) []byte {
 	if cutset == "" {
 		return s
 	}
-	if len(cutset) == 1 && cutset[0] < utf8.RuneSelf {
+	if len(cutset) == 1 && cutset[0] < unicode_utf8__RuneSelf {
 		return trimLeftByte(s, cutset[0])
 	}
-	if as, ok := makeASCIISet(cutset); ok {
-		return trimLeftASCII(s, &as)
+	//gobra:rewrite 02e8fa567eed1a77793874c0a530f453e89ef951a7e1262e8af97f1d29b0e426
+	//gobra:cont 	if as, ok := makeASCIISet(cutset); ok {
+	//gobra:cont 		return trimLeftASCII(s, &as)
+	//gobra:end-old-code 02e8fa567eed1a77793874c0a530f453e89ef951a7e1262e8af97f1d29b0e426
+	if asc, ok := makeASCIISet(cutset); ok {
+		return trimLeftASCII(s, &asc)
+		//gobra:endrewrite 02e8fa567eed1a77793874c0a530f453e89ef951a7e1262e8af97f1d29b0e426
 	}
 	return trimLeftUnicode(s, cutset)
 }
 
+// @ preserves forall i int :: {&s[i]} 0 <= i && i < len(s) ==> acc(&s[i], _)
 func trimLeftByte(s []byte, c byte) []byte {
+	// @ invariant forall i int :: {&s[i]} 0 <= i && i < len(s) ==> acc(&s[i], _)
 	for len(s) > 0 && s[0] == c {
+		// @ assert forall i int :: {&s[1:][i]} 0 <= i && i < len(s[1:]) ==> &s[1:][i] == &s[i+1]
 		s = s[1:]
 	}
 	if len(s) == 0 {
@@ -947,11 +1495,24 @@ func trimLeftByte(s []byte, c byte) []byte {
 	return s
 }
 
-func trimLeftASCII(s []byte, as *asciiSet) []byte {
+// @ preserves forall i int :: {&s[i]} 0 <= i && i < len(s) ==> acc(&s[i], _)
+//
+// @ preserves acc(asc, _)
+//
+//gobra:rewrite 0387089c2272afa3e2a8a1a4875bb9c5c94815f4578982adbe8355e0dc4bb562
+//gobra:cont func trimLeftASCII(s []byte, as *asciiSet) []byte {
+//gobra:cont 	for len(s) > 0 {
+//gobra:cont 		if !as.contains(s[0]) {
+//gobra:end-old-code 0387089c2272afa3e2a8a1a4875bb9c5c94815f4578982adbe8355e0dc4bb562
+func trimLeftASCII(s []byte, asc *asciiSet) []byte {
+	// @ invariant forall i int :: {&s[i]} 0 <= i && i < len(s) ==> acc(&s[i], _)
+	// @ invariant acc(asc, _)
 	for len(s) > 0 {
-		if !as.contains(s[0]) {
+		if !asc.contains(s[0]) {
+			//gobra:endrewrite 0387089c2272afa3e2a8a1a4875bb9c5c94815f4578982adbe8355e0dc4bb562
 			break
 		}
+		// @ assert forall i int :: {&s[1:][i]} 0 <= i && i < len(s[1:]) ==> &s[1:][i] == &s[i+1]
 		s = s[1:]
 	}
 	if len(s) == 0 {
@@ -961,16 +1522,31 @@ func trimLeftASCII(s []byte, as *asciiSet) []byte {
 	return s
 }
 
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
 func trimLeftUnicode(s []byte, cutset string) []byte {
+	// @ ghost olds := s
+	// @ ghost idx := 0
+	// @ invariant 0 <= idx && idx <= len(olds)
+	// @ invariant olds[idx:] === s
+	// @ invariant acc(sl.Bytes(olds, 0, len(olds)), R40)
 	for len(s) > 0 {
+		// @ unfold acc(sl.Bytes(olds, 0, len(olds)), R40)
+		// @ assert forall j int :: {&olds[idx:][j]} 0 <= j && j < len(olds[idx:]) ==> &olds[idx:][j] == &olds[j+idx]
+		// @ assert forall j int :: {&olds[idx:][j]} 0 <= j && j < len(olds[idx:]) ==> &olds[idx:][j] == &s[j]
 		r, n := rune(s[0]), 1
-		if r >= utf8.RuneSelf {
-			r, n = utf8.DecodeRune(s)
+		if r >= unicode_utf8__RuneSelf {
+			// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
+			r, n = unicode_utf8__DecodeRune(s)
+			// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
 		}
 		if !containsRune(cutset, r) {
+			// @ fold acc(sl.Bytes(olds, 0, len(olds)), R40)
 			break
 		}
+		// @ assert forall i int :: {&s[n:][i]} 0 <= i && i < len(s[n:]) ==> &s[n:][i] == &s[i+n]
 		s = s[n:]
+		// @ idx += n
+		// @ fold acc(sl.Bytes(olds, 0, len(olds)), R40)
 	}
 	if len(s) == 0 {
 		// This is what we've historically done.
@@ -981,74 +1557,172 @@ func trimLeftUnicode(s []byte, cutset string) []byte {
 
 // TrimRight returns a subslice of s by slicing off all trailing
 // UTF-8-encoded code points that are contained in cutset.
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+//
+// @ trusted
 func TrimRight(s []byte, cutset string) []byte {
 	if len(s) == 0 || cutset == "" {
 		return s
 	}
-	if len(cutset) == 1 && cutset[0] < utf8.RuneSelf {
+	if len(cutset) == 1 && cutset[0] < unicode_utf8__RuneSelf {
 		return trimRightByte(s, cutset[0])
 	}
-	if as, ok := makeASCIISet(cutset); ok {
-		return trimRightASCII(s, &as)
+	//gobra:rewrite 6b32179dcd0024634836ba05365a9b23b3c72a83392c21e0d427fcbef33f3335
+	//gobra:cont 	if as, ok := makeASCIISet(cutset); ok {
+	//gobra:cont 		return trimRightASCII(s, &as)
+	//gobra:end-old-code 6b32179dcd0024634836ba05365a9b23b3c72a83392c21e0d427fcbef33f3335
+	if asc, ok := makeASCIISet(cutset); ok {
+		return trimRightASCII(s, &asc)
+		//gobra:endrewrite 6b32179dcd0024634836ba05365a9b23b3c72a83392c21e0d427fcbef33f3335
 	}
 	return trimRightUnicode(s, cutset)
 }
 
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
 func trimRightByte(s []byte, c byte) []byte {
-	for len(s) > 0 && s[len(s)-1] == c {
+	//gobra:rewrite 31b9f02d21540a41351d8bce67a9db8399d8c59e6312bcf5ebe870692897747f
+	//gobra:cont 	for len(s) > 0 && s[len(s)-1] == c {
+	//gobra:cont 		s = s[:len(s)-1]
+	//gobra:cont 	}
+	//gobra:end-old-code 31b9f02d21540a41351d8bce67a9db8399d8c59e6312bcf5ebe870692897747f
+	// @ ghost olds := s
+	// @ ghost idx := len(s)
+	// @ invariant 0 <= idx && idx <= len(olds)
+	// @ invariant olds[:idx] === s
+	// @ invariant acc(sl.Bytes(olds, 0, len(olds)), R40)
+	for len(s) > 0 && /* @ unfolding acc(sl.Bytes(olds, 0, len(olds)), R40) in @ */ s[len(s)-1] == c {
+		// @ unfold acc(sl.Bytes(olds, 0, len(olds)), R40)
+		// @ assert forall j int :: {&olds[0:idx][j]} 0 <= j && j < len(olds[0:idx]) ==> &olds[0:idx][j] == &olds[j]
+		// @ assert forall j int :: {&olds[0:idx][j]} 0 <= j && j < len(olds[0:idx]) ==> &olds[0:idx][j] == &s[j]
+		// @ idx = len(s)-1
 		s = s[:len(s)-1]
+		// @ fold acc(sl.Bytes(olds, 0, len(olds)), R40)
 	}
+	//gobra:endrewrite 31b9f02d21540a41351d8bce67a9db8399d8c59e6312bcf5ebe870692897747f
 	return s
 }
 
-func trimRightASCII(s []byte, as *asciiSet) []byte {
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+//
+// @ preserves acc(asc, R40)
+//
+//gobra:rewrite 8c5e716b23a66f72365a9505e211ec2676a538b1b7f603a6a87fa45a9448fab6
+//gobra:cont func trimRightASCII(s []byte, as *asciiSet) []byte {
+//gobra:cont 	for len(s) > 0 {
+//gobra:cont 		if !as.contains(s[len(s)-1]) {
+//gobra:end-old-code 8c5e716b23a66f72365a9505e211ec2676a538b1b7f603a6a87fa45a9448fab6
+func trimRightASCII(s []byte, asc *asciiSet) []byte {
+	// @ ghost olds := s
+	// @ ghost idx := len(s)
+	// @ invariant 0 <= idx && idx <= len(olds)
+	// @ invariant olds[:idx] === s
+	// @ invariant acc(sl.Bytes(olds, 0, len(olds)), R40)
+	// @ invariant acc(asc, R40)
 	for len(s) > 0 {
-		if !as.contains(s[len(s)-1]) {
+		// @ unfold acc(sl.Bytes(olds, 0, len(olds)), R40)
+		// @ assert forall j int :: {&olds[0:idx][j]} 0 <= j && j < len(olds[0:idx]) ==> &olds[0:idx][j] == &olds[j]
+		// @ assert forall j int :: {&olds[0:idx][j]} 0 <= j && j < len(olds[0:idx]) ==> &olds[0:idx][j] == &s[j]
+		if !asc.contains(s[len(s)-1]) {
+			// @ fold acc(sl.Bytes(olds, 0, len(olds)), R40)
+			//gobra:endrewrite 8c5e716b23a66f72365a9505e211ec2676a538b1b7f603a6a87fa45a9448fab6
 			break
 		}
+		// @ idx = len(s)-1
 		s = s[:len(s)-1]
+		// @ fold acc(sl.Bytes(olds, 0, len(olds)), R40)
 	}
 	return s
 }
 
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
 func trimRightUnicode(s []byte, cutset string) []byte {
+	// @ ghost olds := s
+	// @ ghost idx := len(s)
+	// @ invariant 0 <= idx && idx <= len(olds)
+	// @ invariant olds[:idx] === s
+	// @ invariant acc(sl.Bytes(olds, 0, len(olds)), R40)
 	for len(s) > 0 {
+		// @ unfold acc(sl.Bytes(olds, 0, len(olds)), R40)
+		// @ assert forall j int :: {olds[0:idx][j]} 0 <= j && j < len(olds[0:idx]) ==> &olds[0:idx][j] == &olds[j]
+		// @ assert forall j int :: {&olds[0:idx][j]} 0 <= j && j < len(olds[0:idx]) ==> &olds[0:idx][j] == &s[j]
 		r, n := rune(s[len(s)-1]), 1
-		if r >= utf8.RuneSelf {
-			r, n = utf8.DecodeLastRune(s)
+		if r >= unicode_utf8__RuneSelf {
+			r, n = unicode_utf8__DecodeLastRune(s)
 		}
 		if !containsRune(cutset, r) {
+			// @ fold acc(sl.Bytes(olds, 0, len(olds)), R40)
 			break
 		}
+		// @ assert n <= len(s)
+		// @ idx = len(s)-n
 		s = s[:len(s)-n]
+		// @ fold acc(sl.Bytes(olds, 0, len(olds)), R40)
 	}
 	return s
 }
 
 // TrimSpace returns a subslice of s by slicing off all leading and
 // trailing white space, as defined by Unicode.
-func TrimSpace(s []byte) []byte {
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+func TrimSpace(s []byte) (res []byte) {
 	// Fast path for ASCII: look for the first ASCII non-space byte
 	start := 0
+	// @ invariant acc(sl.Bytes(s, 0, len(s)), R40)
+	// @ invariant 0 <= start && start <= len(s)
 	for ; start < len(s); start++ {
+		// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
 		c := s[start]
-		if c >= utf8.RuneSelf {
+		if c >= unicode_utf8__RuneSelf {
 			// If we run into a non-ASCII byte, fall back to the
 			// slower unicode-aware method on the remaining bytes
-			return TrimFunc(s[start:], unicode.IsSpace)
+			//gobra:rewrite b208b2fc84fdec6980efcf6edd6d2e889e1c30b2f474d6c0f45409e7fcac7947
+			//gobra:cont 			return TrimFunc(s[start:], unicode__IsSpace)
+			//gobra:end-old-code b208b2fc84fdec6980efcf6edd6d2e889e1c30b2f474d6c0f45409e7fcac7947
+			// @ assert forall i int :: {&s[start:][i]} 0 <= i && i < len(s[start:]) ==> &s[start:][i] == &s[i+start]
+			// @ fold acc(sl.Bytes(s[start:], 0, len(s[start:])), R40)
+			res = TrimFunc(s[start:], unicode__IsSpace)
+			// @ unfold acc(sl.Bytes(s[start:], 0, len(s[start:])), R40)
+			// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
+			return res
+			//gobra:endrewrite b208b2fc84fdec6980efcf6edd6d2e889e1c30b2f474d6c0f45409e7fcac7947
 		}
+		// @ b.ByteValue(c)
 		if asciiSpace[c] == 0 {
+			// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 			break
 		}
+		// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 	}
+	// @ assert start <= len(s)
 
 	// Now look for the first ASCII non-space byte from the end
 	stop := len(s)
+	// @ oldStart := start
+	// @ invariant acc(sl.Bytes(s, 0, len(s)), R40)
+	// @ invariant 0 <= start && start <= len(s)
+	// @ invariant old(start) == start
+	// @ invariant start == oldStart
+	// @ invariant stop <= len(s)
+	// @ invariant start <= stop
 	for ; stop > start; stop-- {
+		// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
 		c := s[stop-1]
-		if c >= utf8.RuneSelf {
-			return TrimFunc(s[start:stop], unicode.IsSpace)
+		// @ b.ByteValue(c)
+		if c >= unicode_utf8__RuneSelf {
+			// @ assert forall i int :: {&s[start:stop][i]} 0 <= i && i < len(s[start:stop]) ==> &s[start:stop][i] == &s[i+start]
+			//gobra:rewrite a3f298cff5d32351f7602fe0f87e35604223b1ccb74508953fa6c004bb35b87a
+			//gobra:cont 			return TrimFunc(s[start:stop], unicode__IsSpace)
+			//gobra:end-old-code a3f298cff5d32351f7602fe0f87e35604223b1ccb74508953fa6c004bb35b87a
+			// @ fold acc(sl.Bytes(s[start:stop], 0, len(s[start:stop])), R40)
+			res = TrimFunc(s[start:stop], unicode__IsSpace)
+			// @ unfold acc(sl.Bytes(s[start:stop], 0, len(s[start:stop])), R40)
+			// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
+			return res
+			//gobra:endrewrite a3f298cff5d32351f7602fe0f87e35604223b1ccb74508953fa6c004bb35b87a
 		}
+		// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 		if asciiSpace[c] == 0 {
 			break
 		}
@@ -1062,19 +1736,60 @@ func TrimSpace(s []byte) []byte {
 		// returning nil instead of empty slice if all spaces.
 		return nil
 	}
+	// @ assert 0 <= start && start <= stop && stop <= len(s)
+	// @ assert forall i int :: {&s[start:stop][i]} 0 <= i && i < len(s[start:stop]) ==> &s[start:stop][i] == &s[i+start]
 	return s[start:stop]
 }
 
 // Runes interprets s as a sequence of UTF-8-encoded code points.
 // It returns a slice of runes (Unicode code points) equivalent to s.
-func Runes(s []byte) []rune {
-	t := make([]rune, utf8.RuneCount(s))
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+//
+// @ ensures sl.Runes(res, 0, len(res))
+//
+// @ ensures sl.ViewRunes(res) == unicode_utf8__Codepoints(s)
+func Runes(s []byte) (res []rune) {
+	//gobra:rewrite 5aab27295fdb5ccf8c220250bc5b75224bfd961a47a286501fad584575d50cda
+	//gobra:cont 	t := make([]rune, unicode_utf8__RuneCount(s))
+	//gobra:end-old-code 5aab27295fdb5ccf8c220250bc5b75224bfd961a47a286501fad584575d50cda
+	tLength /* @, indices @*/ := unicode_utf8__RuneCount(s)
+	t := make([]rune, tLength)
+	//gobra:endrewrite 5aab27295fdb5ccf8c220250bc5b75224bfd961a47a286501fad584575d50cda
 	i := 0
+
+	// @ ghost olds := s
+	// @ ghost idx := 0
+	// @ ghost codepoints := unicode_utf8__Codepoints(s)
+	// @ fold sl.Runes(t, 0, len(t))
+	// @ invariant i <= idx
+	// @ invariant 0 <= idx && idx <= len(olds)
+	// @ invariant acc(sl.Bytes(olds, 0, len(olds)), R40)
+	// @ invariant olds[idx:] === s
+	// @ invariant sl.Runes(t, 0, len(t))
+	// @ invariant unicode_utf8__Codepoints(s) == codepoints[i:]
+	// @ invariant 0 <= i && i <= len(t)
+	// @ invariant i == len(t) - len(unicode_utf8__Codepoints(s))
+	// @ invariant len(s) > 0 ==> i < len(t)
+	// @ invariant sl.ViewRunes(t)[:i] == codepoints[:i]
+	// @ decreases len(s)
 	for len(s) > 0 {
-		r, l := utf8.DecodeRune(s)
+		// @ unfold sl.Runes(t, 0, len(t))
+		// @ unfold acc(sl.Bytes(olds, 0, len(olds)), R40)
+		// @ assert forall j int :: {&olds[idx:][j]} 0 <= j && j < len(olds[idx:]) ==> &olds[idx:][j] == &olds[j+idx]
+		// @ assert forall j int :: {&olds[idx:][j]} 0 <= j && j < len(olds[idx:]) ==> &olds[idx:][j] == &s[j]
+		// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
+		r, l := unicode_utf8__DecodeRune(s)
+		// @ assert codepoints[i] == r
+		// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
 		t[i] = r
 		i++
+		// @ assert forall i int :: {s[l:][i]} 0 <= i && i < len(s[l:]) ==> &s[l:][i] == &s[i+l]
 		s = s[l:]
+		// @ idx += l
+		// @ assert i <= idx
+		// @ fold acc(sl.Bytes(olds, 0, len(olds)), R40)
+		// @ fold sl.Runes(t, 0, len(t))
 	}
 	return t
 }
@@ -1085,39 +1800,81 @@ func Runes(s []byte) []rune {
 // and after each UTF-8 sequence, yielding up to k+1 replacements
 // for a k-rune slice.
 // If n < 0, there is no limit on the number of replacements.
-func Replace(s, old, new []byte, n int) []byte {
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+//
+// @ preserves acc(sl.Bytes(oldval, 0, len(oldval)), R40)
+//
+// @ preserves acc(sl.Bytes(newval, 0, len(newval)), R40)
+// @ trusted
+//
+//gobra:rewrite 97d56fc6453211521dade272298f0508c52e5884a5900aa9e86582e4e7cfd59f
+//gobra:cont func Replace(s, old, new []byte, n int) []byte {
+//gobra:end-old-code 97d56fc6453211521dade272298f0508c52e5884a5900aa9e86582e4e7cfd59f
+func Replace(s, oldval, newval []byte, n int) (res []byte) {
+	//gobra:endrewrite 97d56fc6453211521dade272298f0508c52e5884a5900aa9e86582e4e7cfd59f
 	m := 0
 	if n != 0 {
 		// Compute number of replacements.
-		m = Count(s, old)
+		//gobra:rewrite d201f42888b2fb247d6f7dd72386a7cdc829fb1878e152fdf84508118901575d
+		//gobra:cont 		m = Count(s, old)
+		//gobra:end-old-code d201f42888b2fb247d6f7dd72386a7cdc829fb1878e152fdf84508118901575d
+		m /* @, _ @ */ = Count(s, oldval)
+		//gobra:endrewrite d201f42888b2fb247d6f7dd72386a7cdc829fb1878e152fdf84508118901575d
 	}
 	if m == 0 {
 		// Just return a copy.
-		return append([]byte(nil), s...)
+		//gobra:rewrite 918b6bf86b6e1ca9ad4e6d479eb9d5e43e5144ca22bdd91d826ce77fb1a17594
+		//gobra:cont 		return append( /* @ R40,  @ */ []byte(nil), s...)
+		//gobra:end-old-code 918b6bf86b6e1ca9ad4e6d479eb9d5e43e5144ca22bdd91d826ce77fb1a17594
+
+		// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
+		res = append( /* @ R40, @ */ []byte(nil), s...)
+		// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
+		return res
+		//gobra:endrewrite 918b6bf86b6e1ca9ad4e6d479eb9d5e43e5144ca22bdd91d826ce77fb1a17594
 	}
 	if n < 0 || m < n {
 		n = m
 	}
 
 	// Apply replacements to buffer.
-	t := make([]byte, len(s)+n*(len(new)-len(old)))
+	//gobra:rewrite c787ef8de608ddf205718721d556dee5a732bac8dce3fa92ce9f2266fe7bc2a1
+	//gobra:cont 	t := make([]byte, len(s)+n*(len(new)-len(old)))
+	//gobra:end-old-code c787ef8de608ddf205718721d556dee5a732bac8dce3fa92ce9f2266fe7bc2a1
+	// @ assert len(s) >= n*(len(oldval) - len(newval))
+	t := make([]byte, len(s)+n*(len(newval)-len(oldval)))
+	//gobra:endrewrite c787ef8de608ddf205718721d556dee5a732bac8dce3fa92ce9f2266fe7bc2a1
 	w := 0
 	start := 0
 	for i := 0; i < n; i++ {
 		j := start
-		if len(old) == 0 {
+		//gobra:rewrite 945fbe50b78d9a29bb15d5eaedeaf126427abf5df5d10795b8c3eae67c53cab9
+		//gobra:cont 		if len(old) == 0 {
+		//gobra:end-old-code 945fbe50b78d9a29bb15d5eaedeaf126427abf5df5d10795b8c3eae67c53cab9
+		if len(oldval) == 0 {
+			//gobra:endrewrite 945fbe50b78d9a29bb15d5eaedeaf126427abf5df5d10795b8c3eae67c53cab9
 			if i > 0 {
-				_, wid := utf8.DecodeRune(s[start:])
+				_, wid := unicode_utf8__DecodeRune(s[start:])
 				j += wid
 			}
 		} else {
-			j += Index(s[start:], old)
+			//gobra:rewrite c485492729f4eaac8633c92b5d0f51e439032888b93389e82c6b2202e864ca4b
+			//gobra:cont 			j += Index(s[start:], old)
+			//gobra:end-old-code c485492729f4eaac8633c92b5d0f51e439032888b93389e82c6b2202e864ca4b
+			j += Index(s[start:], oldval)
+			//gobra:endrewrite c485492729f4eaac8633c92b5d0f51e439032888b93389e82c6b2202e864ca4b
 		}
-		w += copy(t[w:], s[start:j])
-		w += copy(t[w:], new)
-		start = j + len(old)
+		w += copy(t[w:], s[start:j] /* @, R40 @ */)
+		//gobra:rewrite 192a485aaa164f7b2c5f7c7f1833b5d50b78f226160b2cac46692dc4a7bedb30
+		//gobra:cont 		w += copy(t[w:], new)
+		//gobra:cont 		start = j + len(old)
+		//gobra:end-old-code 192a485aaa164f7b2c5f7c7f1833b5d50b78f226160b2cac46692dc4a7bedb30
+		w += copy(t[w:], newval /* @, R40 @ */)
+		start = j + len(oldval)
+		//gobra:endrewrite 192a485aaa164f7b2c5f7c7f1833b5d50b78f226160b2cac46692dc4a7bedb30
 	}
-	w += copy(t[w:], s[start:])
+	w += copy(t[w:], s[start:] /* @, R40 @ */)
 	return t[0:w]
 }
 
@@ -1126,20 +1883,38 @@ func Replace(s, old, new []byte, n int) []byte {
 // If old is empty, it matches at the beginning of the slice
 // and after each UTF-8 sequence, yielding up to k+1 replacements
 // for a k-rune slice.
-func ReplaceAll(s, old, new []byte) []byte {
-	return Replace(s, old, new, -1)
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+//
+// @ preserves acc(sl.Bytes(oldval, 0, len(oldval)), R40)
+//
+// @ preserves acc(sl.Bytes(newval, 0, len(newval)), R40)
+//
+//gobra:rewrite 97c2ede7687475e639eb6cf004d3abccbd534c90686609842d241e0faf3710c5
+//gobra:cont func ReplaceAll(s, old, new []byte) []byte {
+//gobra:cont 	return Replace(s, old, new, -1)
+//gobra:cont }
+//gobra:end-old-code 97c2ede7687475e639eb6cf004d3abccbd534c90686609842d241e0faf3710c5
+func ReplaceAll(s, oldval, newval []byte) []byte {
+	return Replace(s, oldval, newval, -1)
 }
 
 // EqualFold reports whether s and t, interpreted as UTF-8 strings,
 // are equal under simple Unicode case-folding, which is a more general
 // form of case-insensitivity.
-func EqualFold(s, t []byte) bool {
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+//
+// @ preserves acc(sl.Bytes(t, 0, len(t)), R40)
+//
+// @ // we cannot yet verify the body of this function, since it contains `goto`: see gobra issue #783
+func EqualFold(s, t []byte) bool /* {
 	// ASCII fast path
 	i := 0
 	for ; i < len(s) && i < len(t); i++ {
 		sr := s[i]
 		tr := t[i]
-		if sr|tr >= utf8.RuneSelf {
+		if sr|tr >= unicode_utf8__RuneSelf {
 			goto hasUnicode
 		}
 
@@ -1167,16 +1942,16 @@ hasUnicode:
 	for len(s) != 0 && len(t) != 0 {
 		// Extract first rune from each.
 		var sr, tr rune
-		if s[0] < utf8.RuneSelf {
+		if s[0] < unicode_utf8__RuneSelf {
 			sr, s = rune(s[0]), s[1:]
 		} else {
-			r, size := utf8.DecodeRune(s)
+			r, size := unicode_utf8__DecodeRune(s)
 			sr, s = r, s[size:]
 		}
-		if t[0] < utf8.RuneSelf {
+		if t[0] < unicode_utf8__RuneSelf {
 			tr, t = rune(t[0]), t[1:]
 		} else {
-			r, size := utf8.DecodeRune(t)
+			r, size := unicode_utf8__DecodeRune(t)
 			tr, t = r, t[size:]
 		}
 
@@ -1192,7 +1967,7 @@ hasUnicode:
 			tr, sr = sr, tr
 		}
 		// Fast check for ASCII.
-		if tr < utf8.RuneSelf {
+		if tr < unicode_utf8__RuneSelf {
 			// ASCII only, sr/tr must be upper/lower case
 			if 'A' <= sr && sr <= 'Z' && tr == sr+'a'-'A' {
 				continue
@@ -1202,9 +1977,9 @@ hasUnicode:
 
 		// General case. SimpleFold(x) returns the next equivalent rune > x
 		// or wraps around to smaller values.
-		r := unicode.SimpleFold(sr)
+		r := unicode__SimpleFold(sr)
 		for r != sr && r < tr {
-			r = unicode.SimpleFold(r)
+			r = unicode__SimpleFold(r)
 		}
 		if r == tr {
 			continue
@@ -1214,16 +1989,29 @@ hasUnicode:
 
 	// One string is empty. Are both?
 	return len(s) == len(t)
-}
+} */
 
 // Index returns the index of the first instance of sep in s, or -1 if sep is not present in s.
-func Index(s, sep []byte) int {
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+//
+// @ preserves acc(sl.Bytes(sep, 0, len(sep)), R40)
+//
+// @ ensures res == -1 || (0 <= res && res + len(sep) <= len(s))
+//
+// @ ensures res != -1 ==> forall i int :: {&s[res:res+len(sep)][i]}{&s[i+res]} 0 <= i && i < len(s[res:res+len(sep)]) ==> &s[res:res+len(sep)][i] == &s[i+res]
+//
+// @ ensures res != -1 ==> View(s)[res:res+len(sep)] == View(sep)
+//
+// @ ensures res == -1 ==> forall i int :: {View(s)[i:i+len(sep)]} 0 <= i && i + len(sep) <= len(s) ==> View(s)[i:i+len(sep)] != View(sep)
+func Index(s, sep []byte) (res int) {
 	n := len(sep)
 	switch {
 	case n == 0:
 		return 0
 	case n == 1:
-		return IndexByte(s, sep[0])
+		return IndexByte(s,
+			/* @ unfolding acc(sl.Bytes(sep, 0, len(sep)), R40) in @ */ sep[0])
 	case n == len(s):
 		if Equal(sep, s) {
 			return 0
@@ -1231,58 +2019,125 @@ func Index(s, sep []byte) int {
 		return -1
 	case n > len(s):
 		return -1
-	case n <= bytealg.MaxLen:
+	case n <= internal_bytealg__MaxLen:
 		// Use brute force when s and sep both are small
-		if len(s) <= bytealg.MaxBruteForce {
-			return bytealg.Index(s, sep)
+		if len(s) <= internal_bytealg__MaxBruteForce {
+			return internal_bytealg__Index(s, sep)
 		}
+		// @ unfold acc(sl.Bytes(sep, 0, len(sep)), R40)
 		c0 := sep[0]
 		c1 := sep[1]
+		// @ fold acc(sl.Bytes(sep, 0, len(sep)), R40)
 		i := 0
 		t := len(s) - n + 1
 		fails := 0
+		// @ ghost vsep := View(sep)
+		// @ ghost vs := View(s)
+		// @ invariant acc(sl.Bytes(s, 0, len(s)), R40)
+		// @ invariant acc(sl.Bytes(sep, 0, len(sep)), R40)
+		// @ invariant vs == View(s)
+		// @ invariant vsep == View(sep)
+		// @ invariant c0 == View(sep)[0]
+		// @ invariant c1 == View(sep)[1]
+		// @ invariant i >= 0
+		// @ invariant fails >= 0
+		// @ invariant t == len(s) - n + 1
+		// @ invariant forall j int :: { vs[j:j+len(sep)] } 0 <= j && j < i ==> vs[j:j+len(sep)] != vsep
 		for i < t {
+			// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
 			if s[i] != c0 {
 				// IndexByte is faster than bytealg.Index, so use it as long as
 				// we're not getting lots of false positives.
+				// @ assert forall j int :: {&s[i+1:t][j]} 0 <= j && j < len(s[i+1:t]) ==> &s[i+1:t][j] == &s[j+i+1]
+				// @ fold acc(sl.Bytes(s[i+1:t], 0, len(s[i+1:t])), R40)
 				o := IndexByte(s[i+1:t], c0)
+				// @ assert View(s[i+1:t]) == vs[i+1:t]
+				// @ unfold acc(sl.Bytes(s[i+1:t], 0, len(s[i+1:t])), R40)
+
 				if o < 0 {
+					// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 					return -1
 				}
 				i += o + 1
 			}
-			if s[i+1] == c1 && Equal(s[i:i+n], sep) {
+
+			// @ assert forall j int :: {&s[i:i+n][j]} 0 <= j && j < len(s[i:i+n]) ==> &s[i:i+n][j] == &s[j+i]
+			//gobra:rewrite 7bafdf7e4e13158c42c57d2807162d86acab287627cdfddb8689900171421936
+			//gobra:cont 			if s[i+1] == c1 && Equal(s[i:i+n], sep) {
+			//gobra:end-old-code 7bafdf7e4e13158c42c57d2807162d86acab287627cdfddb8689900171421936
+			p1 := s[i+1] == c1
+			// @ fold acc(sl.Bytes(s[i:i+n], 0, len(s[i:i+n])), R40)
+			if p1 && Equal(s[i:i+n], sep) {
+				//gobra:endrewrite 7bafdf7e4e13158c42c57d2807162d86acab287627cdfddb8689900171421936
+				// @ unfold acc(sl.Bytes(s[i:i+n], 0, len(s[i:i+n])), R40)
+				// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 				return i
 			}
+			// @ unfold acc(sl.Bytes(s[i:i+n], 0, len(s[i:i+n])), R40)
 			fails++
 			i++
 			// Switch to bytealg.Index when IndexByte produces too many false positives.
-			if fails > bytealg.Cutover(i) {
-				r := bytealg.Index(s[i:], sep)
+			if fails > internal_bytealg__Cutover(i) {
+				// @ assert forall j int :: {&s[i:][j]} 0 <= j && j < len(s[i:]) ==> &s[i:][j] == &s[j+i]
+				// @ fold acc(sl.Bytes(s[i:], 0, len(s[i:])), R40)
+				r := internal_bytealg__Index(s[i:], sep)
+				// @ unfold acc(sl.Bytes(s[i:], 0, len(s[i:])), R40)
 				if r >= 0 {
+					// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 					return r + i
 				}
+				// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 				return -1
 			}
+			// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 		}
 		return -1
 	}
+	// @ unfold acc(sl.Bytes(sep, 0, len(sep)), R40)
 	c0 := sep[0]
 	c1 := sep[1]
+	// @ fold acc(sl.Bytes(sep, 0, len(sep)), R40)
 	i := 0
 	fails := 0
 	t := len(s) - n + 1
+	// @ ghost vsep := View(sep)
+	// @ ghost vs := View(s)
+	// @ invariant acc(sl.Bytes(s, 0, len(s)), R40)
+	// @ invariant acc(sl.Bytes(sep, 0, len(sep)), R40)
+	// @ invariant vs == View(s)
+	// @ invariant vsep == View(sep)
+	// @ invariant c0 == vsep[0]
+	// @ invariant c1 == vsep[1]
+	// @ invariant i >= 0
+	// @ invariant t == len(s) - n + 1
+	// @ invariant forall j int :: { vs[j:j+len(sep)] } 0 <= j && j < i ==> vs[j:j+len(sep)] != vsep
 	for i < t {
+		// @ unfold acc(sl.Bytes(s, 0, len(s)), R40)
 		if s[i] != c0 {
+			// @ assert forall j int :: {&s[i+1:t][j]} 0 <= j && j < len(s[i+1:t]) ==> &s[i+1:t][j] == &s[j+i+1]
+			// @ fold acc(sl.Bytes(s[i+1:t], 0, len(s[i+1:t])), R40)
 			o := IndexByte(s[i+1:t], c0)
+			// @ assert View(s[i+1:t]) == vs[i+1:t]
+			// @ unfold acc(sl.Bytes(s[i+1:t], 0, len(s[i+1:t])), R40)
 			if o < 0 {
+				// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 				break
 			}
 			i += o + 1
 		}
-		if s[i+1] == c1 && Equal(s[i:i+n], sep) {
+		//gobra:rewrite 5e92da7b0d472efdc4e87211ab9ead496a89c44d2219edf05a825aa7b3088140
+		//gobra:cont 		if s[i+1] == c1 && Equal(s[i:i+n], sep) {
+		//gobra:end-old-code 5e92da7b0d472efdc4e87211ab9ead496a89c44d2219edf05a825aa7b3088140
+		p1 := s[i+1] == c1
+		// @ assert forall j int :: {&s[i:i+n][j]} 0 <= j && j < len(s[i:i+n]) ==> &s[i:i+n][j] == &s[j+i]
+		// @ fold acc(sl.Bytes(s[i:i+n], 0, len(s[i:i+n])), R40)
+		if p1 && Equal(s[i:i+n], sep) {
+			// @ unfold acc(sl.Bytes(s[i:i+n], 0, len(s[i:i+n])), R40)
+			//gobra:endrewrite 5e92da7b0d472efdc4e87211ab9ead496a89c44d2219edf05a825aa7b3088140
+			// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 			return i
 		}
+		// @ unfold acc(sl.Bytes(s[i:i+n], 0, len(s[i:i+n])), R40)
 		i++
 		fails++
 		if fails >= 4+i>>4 && i < t {
@@ -1294,13 +2149,20 @@ func Index(s, sep []byte) int {
 			// we should cutover at even larger average skips,
 			// because Equal becomes that much more expensive.
 			// This code does not take that effect into account.
-			j := bytealg.IndexRabinKarpBytes(s[i:], sep)
+			// @ assert forall j int :: {&s[i:][j]} 0 <= j && j < len(s[i:]) ==> &s[i:][j] == &s[j+i]
+			// @ fold acc(sl.Bytes(s[i:], 0, len(s[i:])), R40)
+			j := internal_bytealg__IndexRabinKarpBytes(s[i:], sep)
+			// @ unfold acc(sl.Bytes(s[i:], 0, len(s[i:])), R40)
 			if j < 0 {
+				// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 				return -1
 			}
+			// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 			return i + j
 		}
+		// @ fold acc(sl.Bytes(s, 0, len(s)), R40)
 	}
+	// @ assert forall j int :: {vs[j:j+len(sep)]} 0 <= j && j + len(sep) <= len(s) ==> vs[j:j+len(sep)] != vsep
 	return -1
 }
 
@@ -1310,21 +2172,47 @@ func Index(s, sep []byte) int {
 // If sep does not appear in s, cut returns s, nil, false.
 //
 // Cut returns slices of the original slice s, not copies.
-func Cut(s, sep []byte) (before, after []byte, found bool) {
+//
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R40)
+//
+// @ preserves acc(sl.Bytes(sep, 0, len(sep)), R40)
+//
+// @ ensures found ==> len(b) + len(sep) + len(after) == len(s)
+// @ ensures found ==> forall i int :: {&s[:len(b)][i]} 0 <= i && i < len(s[:len(b)]) ==> &s[:len(b)][i] == &b[i]
+// @ ensures found ==> forall i int :: {&s[len(b)+len(sep):][i]} 0 <= i && i < len(s[len(b)+len(sep):]) ==> &s[len(b)+len(sep):][i] == &after[i]
+// @ ensures !found ==> forall i int :: {View(s)[i:i+len(sep)]} 0 <= i && i + len(sep) <= len(s) ==> View(s)[i:i+len(sep)] != View(sep)
+// @ ensures !found ==> len(s) == len(b) && (forall i int :: {&s[i]}{&b[i]} 0 <= i && i < len(s) ==> &s[i] == &b[i]) && after == nil
+//
+//gobra:rewrite e87ea459dcf89b1423be9fd397d8f4767ad24881f1ab27c606aec78e6a86fea4
+//gobra:cont func Cut(s, sep []byte) (before, after []byte, found bool) {
+//gobra:end-old-code e87ea459dcf89b1423be9fd397d8f4767ad24881f1ab27c606aec78e6a86fea4
+func Cut(s, sep []byte) (b, after []byte, found bool) {
+	//gobra:endrewrite e87ea459dcf89b1423be9fd397d8f4767ad24881f1ab27c606aec78e6a86fea4
 	if i := Index(s, sep); i >= 0 {
 		return s[:i], s[i+len(sep):], true
 	}
 	return s, nil, false
 }
 
-// Clone returns a copy of b[:len(b)].
-// The result may have additional unused capacity.
-// Clone(nil) returns nil.
-func Clone(b []byte) []byte {
+// @ preserves acc(sl.Bytes(b, 0, len(b)), R49)
+//
+// @ ensures sl.Bytes(res, 0, len(res))
+//
+// @ ensures View(b) == View(res)
+func Clone(b []byte) (res []byte) {
 	if b == nil {
+		// @ fold sl.Bytes(res, 0, len(res))
 		return nil
 	}
-	return append([]byte{}, b...)
+	//gobra:rewrite 18ffdb418b2210b4a8df68df4e19965b13b5beb29702377d3ae2d6ae4fcc6957
+	//gobra:cont 	return append( /* @ R50, @ */ []byte{}, b...)
+	//gobra:end-old-code 18ffdb418b2210b4a8df68df4e19965b13b5beb29702377d3ae2d6ae4fcc6957
+	// @ unfold acc(sl.Bytes(b, 0, len(b)), R50)
+	res = append( /* @ R50, @ */ []byte{}, b...)
+	// @ fold acc(sl.Bytes(b, 0, len(b)), R50)
+	// @ fold sl.Bytes(res, 0, len(res))
+	return res
+	//gobra:endrewrite 18ffdb418b2210b4a8df68df4e19965b13b5beb29702377d3ae2d6ae4fcc6957
 }
 
 // CutPrefix returns s without the provided leading prefix byte slice
@@ -1333,6 +2221,7 @@ func Clone(b []byte) []byte {
 // If prefix is the empty byte slice, CutPrefix returns s, true.
 //
 // CutPrefix returns slices of the original slice s, not copies.
+// @ trusted
 func CutPrefix(s, prefix []byte) (after []byte, found bool) {
 	if !HasPrefix(s, prefix) {
 		return s, false
@@ -1346,7 +2235,14 @@ func CutPrefix(s, prefix []byte) (after []byte, found bool) {
 // If suffix is the empty byte slice, CutSuffix returns s, true.
 //
 // CutSuffix returns slices of the original slice s, not copies.
-func CutSuffix(s, suffix []byte) (before []byte, found bool) {
+//
+// @ trusted
+//
+//gobra:rewrite 8ffb74d9bb6cd2eea093a78310d9ee0b1bf3464ef13e5e230a4260846c8e2c35
+//gobra:cont func CutSuffix(s, suffix []byte) (before []byte, found bool) {
+//gobra:end-old-code 8ffb74d9bb6cd2eea093a78310d9ee0b1bf3464ef13e5e230a4260846c8e2c35
+func CutSuffix(s, suffix []byte) (b []byte, found bool) {
+	//gobra:endrewrite 8ffb74d9bb6cd2eea093a78310d9ee0b1bf3464ef13e5e230a4260846c8e2c35
 	if !HasSuffix(s, suffix) {
 		return s, false
 	}

--- a/src/bytes/bytes_lemmas.gobra
+++ b/src/bytes/bytes_lemmas.gobra
@@ -1,0 +1,89 @@
+package bytes
+
+// +gobra
+
+import (
+   . "verification/utils/definitions"
+   b "verification/utils/bitwise"
+   sl "verification/utils/slices"
+   seqs "verification/utils/seqs"
+   sets "verification/utils/sets"
+)
+
+
+// Repeat
+
+
+// bp == a
+// i == b
+// bp == len(b) * i
+// bp*2 == len(b) * i*2
+// a2 == len(b) * b2
+ghost
+requires a * 2 == a2
+requires b * 2 == b2
+requires b * 2 == b2
+requires a == c * b
+ensures a2 == c * b2
+decreases
+func lemmaMul2Inj(a, b, a2, b2, c int) {
+
+}
+
+ghost
+requires a == b
+requires b == c
+ensures a == c
+decreases
+func lemmaEqTransitive_seq(a, b, c seq[byte]) {
+
+}
+
+ghost
+ensures SpecRepeat(b, 1) == b
+decreases
+func lemmaSpecRepeat_1(b seq[byte]) {
+	assert SpecRepeat(b, 1) == b ++ SpecRepeat(b, 0)
+}
+
+ghost
+requires n >= 0
+ensures SpecRepeat(b, 2 * n) == SpecRepeat(b, n) ++ SpecRepeat(b, n)
+decreases _
+func lemmaSpecRepeat_2n(b seq[byte], n int) {
+	if n != 0 {
+		assert SpecRepeat(b, n) == b ++ SpecRepeat(b, n - 1)
+		assert SpecRepeat(b, n) ++ SpecRepeat(b, n) == b ++ SpecRepeat(b, n - 1) ++ b ++ SpecRepeat(b, n - 1)
+		// order of repeating doesn't matter because it's always the same element that is repeated
+		assume b ++ SpecRepeat(b, n - 1) ++ b ++ SpecRepeat(b, n - 1) == b ++ b ++ SpecRepeat(b, n - 1) ++ SpecRepeat(b, n - 1)
+		lemmaSpecRepeat_2n(b, n - 1)
+		assert SpecRepeat(b, n - 1) ++ SpecRepeat(b, n - 1) == SpecRepeat(b, 2 * (n - 1))
+		assert SpecRepeat(b, 2 * n - 1) == b ++ SpecRepeat(b, n - 1) ++ SpecRepeat(b, n - 1)
+		assert SpecRepeat(b, 2 * n) == b ++ b ++ SpecRepeat(b, n - 1) ++ SpecRepeat(b, n - 1)
+	} else {
+		TODO()
+	}
+}
+
+// Count
+
+ghost
+requires s[i:i+len(sep)] == sep
+ensures InRangeInc(i, 0, len(s) - len(sep))
+decreases
+func lemmaCountCanView(s seq[byte], sep seq[byte], i int) {
+	TODO()
+}
+
+ghost
+requires InRangeInc(idx, 0, len(s))
+requires forall j int :: { j in indices }{ s[j:j+len(sep)] } !(j in indices) ==> !(InRangeInc(j, 0, idx - len(sep))) || s[j:j+len(sep)] != sep || SetContainsInRange(indices, j-len(sep), j)
+requires forall j int :: {s[idx:][j:j+len(sep)]} InRangeInc(j, 0, len(s[idx:]) - len(sep)) ==> s[idx:][j:j+len(sep)] != sep
+ensures forall j int :: { j in indices }{ s[j:j+len(sep)] } !(j in indices) ==> ( !InRangeInc(j, 0, len(s) - len(sep)) || s[j:j+len(sep)] != sep || SetContainsInRange(indices, j-len(sep), j))
+decreases
+func lemmaCountAux(s, sep seq[byte], indices set[int], idx int) {
+	assume forall j int :: {s[j:j+len(sep)]} InRangeInc(j, idx, len(s) - len(sep)) ==> s[j:j+len(sep)] != sep
+	assert forall j int :: { j in indices }{ s[j:j+len(sep)] } !(j in indices) && InRangeInc(j, 0, idx - len(sep)) && !SetContainsInRange(indices, j-len(sep), j) ==> s[j:j+len(sep)] != sep
+	assert forall j int :: { j in indices }{ s[j:j+len(sep)] } !(j in indices) && InRangeInc(j, idx, len(s) - len(sep)) && !SetContainsInRange(indices, j-len(sep), j) ==> s[j:j+len(sep)] != sep
+	assume forall j int :: { j in indices }{ s[j:j+len(sep)] } !(j in indices) && InRangeInc(j, 0, len(s) - len(sep)) && !SetContainsInRange(indices, j-len(sep), j) ==> s[j:j+len(sep)] != sep
+}

--- a/src/bytes/bytes_lemmas.gobra
+++ b/src/bytes/bytes_lemmas.gobra
@@ -8,6 +8,7 @@ import (
    sl "verification/utils/slices"
    seqs "verification/utils/seqs"
    sets "verification/utils/sets"
+   . "bytes/spec"
 )
 
 
@@ -87,3 +88,14 @@ func lemmaCountAux(s, sep seq[byte], indices set[int], idx int) {
 	assert forall j int :: { j in indices }{ s[j:j+len(sep)] } !(j in indices) && InRangeInc(j, idx, len(s) - len(sep)) && !SetContainsInRange(indices, j-len(sep), j) ==> s[j:j+len(sep)] != sep
 	assume forall j int :: { j in indices }{ s[j:j+len(sep)] } !(j in indices) && InRangeInc(j, 0, len(s) - len(sep)) && !SetContainsInRange(indices, j-len(sep), j) ==> s[j:j+len(sep)] != sep
 }
+
+ghost
+requires 0 < p
+requires acc(sl.Bytes(a, 0, len(a)), p)
+requires acc(sl.Bytes(b, 0, len(b)), p)
+requires r == ((unfolding acc(sl.Bytes(a, 0, len(a)), p) in string(a)) == (unfolding acc(sl.Bytes(b, 0, len(b)), p) in string(b)))
+ensures acc(sl.Bytes(a, 0, len(a)), p)
+ensures acc(sl.Bytes(b, 0, len(b)), p)
+ensures r == (View(a) == View(b))
+decreases
+func stringEqualsImplViewEquals(r bool, a, b []byte, p perm)

--- a/src/bytes/bytes_lemmas.gobra
+++ b/src/bytes/bytes_lemmas.gobra
@@ -70,7 +70,7 @@ func axiomSpecRepeatCommutative(b seq[byte], n int)
 ghost
 requires n >= 0
 ensures SpecRepeat(b, 2 * n) == SpecRepeat(b, n) ++ SpecRepeat(b, n)
-decreases _
+decreases n
 func lemmaSpecRepeat_2n(b seq[byte], n int) {
 	if n != 0 {
 		assert SpecRepeat(b, n) == b ++ SpecRepeat(b, n - 1)
@@ -136,7 +136,7 @@ func lemmaIndexIndexByteIsNotPrefix(s, sep seq[byte], i, t, o int) {
 	invariant forall j int :: {s[i+1:t][j]} 0 <= j && j < o ==> s[i+1:t][j] != sep[0]
 	invariant i+1 <= idx
 	invariant forall j int :: { s[j:j+len(sep)] } 0 <= j && j < idx ==> s[j:j+len(sep)] != sep
-	decreases _
+	decreases i+o+1-idx
 	for idx := i+1; idx < i+o+1 ; idx++ {
 		assert s[idx] == s[i+1:t][idx - (i+1)]
 		assert s[idx] != sep[0]
@@ -158,7 +158,7 @@ decreases
 func lemmaIndexIndexByteNotFound(s, sep seq[byte], i, t int) {
 	invariant i+1 <= idx
 	invariant forall j int :: { s[j:j+len(sep)] } 0 <= j && j < idx ==> s[j:j+len(sep)] != sep
-	decreases _
+	decreases t-idx
 	for idx := i+1; idx < t; idx++ {
 
 		assert s[idx] == s[i+1:t][idx - (i+1)]

--- a/src/bytes/bytes_lemmas.gobra
+++ b/src/bytes/bytes_lemmas.gobra
@@ -12,6 +12,20 @@ import (
 )
 
 
+ghost
+requires 0 < p1 && 0 < p2
+requires 0 <= start && start <= end && end <= len(s)
+preserves acc(sl.Bytes(s, 0, len(s)), p1)
+preserves acc(sl.Bytes(s[start:end], 0, len(s[start:end])), p2)
+ensures View(s[start:end]) == View(s)[start:end]
+trusted
+decreases _
+func lemmaViewSlice(s []byte, start, end int, p1, p2 perm) {
+	TODO()
+}
+
+
+
 // Repeat
 
 
@@ -75,6 +89,9 @@ func lemmaSpecRepeat_2n(b seq[byte], n int) {
 	}
 }
 
+
+
+
 // Count
 
 ghost
@@ -100,3 +117,62 @@ ensures acc(sl.Bytes(b, 0, len(b)), p)
 ensures r == (View(a) == View(b))
 decreases
 func stringEqualsImplViewEquals(r bool, a, b []byte, p perm)
+
+// index
+
+ghost
+requires 2 <= len(s)
+requires t == len(s) - len(sep) + 1
+requires 0 <= i && i+1 <= t && t <= len(s)
+requires i < t
+requires 0 <= o && o < t-i-1
+requires s[i] != sep[0]
+requires forall j int :: { s[j:j+len(sep)] } 0 <= j && j < i ==> s[j:j+len(sep)] != sep
+requires forall j int :: {s[i+1:t][j]} 0 <= j && j < o ==> s[i+1:t][j] != sep[0]
+ensures  forall j int :: { s[j:j+len(sep)] } 0 <= j && j < i+o+1 ==> s[j:j+len(sep)] != sep
+decreases
+func lemmaIndexIndexByteIsNotPrefix(s, sep seq[byte], i, t, o int) {
+
+	invariant forall j int :: {s[i+1:t][j]} 0 <= j && j < o ==> s[i+1:t][j] != sep[0]
+	invariant i+1 <= idx
+	invariant forall j int :: { s[j:j+len(sep)] } 0 <= j && j < idx ==> s[j:j+len(sep)] != sep
+	decreases _
+	for idx := i+1; idx < i+o+1 ; idx++ {
+		assert s[idx] == s[i+1:t][idx - (i+1)]
+		assert s[idx] != sep[0]
+		assert s[idx:idx+len(sep)] != sep
+	}
+
+}
+
+ghost
+requires 2 <= len(s)
+requires t == len(s) - len(sep) + 1
+requires 0 <= i && i+1 <= t && t <= len(s)
+requires i < t
+requires s[i] != sep[0]
+requires forall j int :: { s[j:j+len(sep)] } 0 <= j && j < i ==> s[j:j+len(sep)] != sep
+requires forall j int :: { s[i+1:t][j] } 0 <= j && j < len(s[i+1:t]) ==> s[i+1:t][j] != sep[0]
+ensures  forall j int :: { s[j:j+len(sep)] } 0 <= j && j < t ==> s[j:j+len(sep)] != sep
+decreases
+func lemmaIndexIndexByteNotFound(s, sep seq[byte], i, t int) {
+	invariant i+1 <= idx
+	invariant forall j int :: { s[j:j+len(sep)] } 0 <= j && j < idx ==> s[j:j+len(sep)] != sep
+	decreases _
+	for idx := i+1; idx < t; idx++ {
+
+		assert s[idx] == s[i+1:t][idx - (i+1)]
+		assert s[idx] != sep[0]
+		assert s[idx:idx+len(sep)] != sep
+	}
+
+}
+
+ghost
+requires forall j int :: { s[j:j+len(sep)] } 0 <= j && j < a ==> s[j:j+len(sep)] != sep
+requires forall j int :: { s[j:j+len(sep)] } a <= j && j < b ==> s[j:j+len(sep)] != sep
+ensures  forall j int :: { s[j:j+len(sep)] } 0 <= j && j < b ==> s[j:j+len(sep)] != sep
+decreases
+func lemmaIndexAdvance(s, sep seq[byte], a, b int) {
+
+}

--- a/src/bytes/bytes_lemmas.gobra
+++ b/src/bytes/bytes_lemmas.gobra
@@ -49,6 +49,12 @@ func lemmaSpecRepeat_1(b seq[byte]) {
 
 ghost
 requires n >= 0
+ensures b ++ SpecRepeat(b, n) == SpecRepeat(b, n) ++ b
+decreases
+func axiomSpecRepeatCommutative(b seq[byte], n int)
+
+ghost
+requires n >= 0
 ensures SpecRepeat(b, 2 * n) == SpecRepeat(b, n) ++ SpecRepeat(b, n)
 decreases _
 func lemmaSpecRepeat_2n(b seq[byte], n int) {
@@ -56,25 +62,20 @@ func lemmaSpecRepeat_2n(b seq[byte], n int) {
 		assert SpecRepeat(b, n) == b ++ SpecRepeat(b, n - 1)
 		assert SpecRepeat(b, n) ++ SpecRepeat(b, n) == b ++ SpecRepeat(b, n - 1) ++ b ++ SpecRepeat(b, n - 1)
 		// order of repeating doesn't matter because it's always the same element that is repeated
-		assume b ++ SpecRepeat(b, n - 1) ++ b ++ SpecRepeat(b, n - 1) == b ++ b ++ SpecRepeat(b, n - 1) ++ SpecRepeat(b, n - 1)
+		assert b ++ SpecRepeat(b, n - 1) ++ b ++ SpecRepeat(b, n - 1) == b ++ (SpecRepeat(b, n - 1) ++ b) ++ SpecRepeat(b, n - 1)
+		axiomSpecRepeatCommutative(b, n - 1)
+		assert b ++ (SpecRepeat(b, n - 1) ++ b) ++ SpecRepeat(b, n - 1) == b ++ (b ++ SpecRepeat(b, n - 1)) ++ SpecRepeat(b, n - 1)
+		assert b ++ SpecRepeat(b, n - 1) ++ b ++ SpecRepeat(b, n - 1) == b ++ b ++ SpecRepeat(b, n - 1) ++ SpecRepeat(b, n - 1)
 		lemmaSpecRepeat_2n(b, n - 1)
 		assert SpecRepeat(b, n - 1) ++ SpecRepeat(b, n - 1) == SpecRepeat(b, 2 * (n - 1))
 		assert SpecRepeat(b, 2 * n - 1) == b ++ SpecRepeat(b, n - 1) ++ SpecRepeat(b, n - 1)
 		assert SpecRepeat(b, 2 * n) == b ++ b ++ SpecRepeat(b, n - 1) ++ SpecRepeat(b, n - 1)
 	} else {
-		TODO()
+		assert SpecRepeat(b, 2 * 0) == SpecRepeat(b, 0) ++ SpecRepeat(b, 0)
 	}
 }
 
 // Count
-
-ghost
-requires s[i:i+len(sep)] == sep
-ensures InRangeInc(i, 0, len(s) - len(sep))
-decreases
-func lemmaCountCanView(s seq[byte], sep seq[byte], i int) {
-	TODO()
-}
 
 ghost
 requires InRangeInc(idx, 0, len(s))

--- a/src/bytes/bytes_spec.gobra
+++ b/src/bytes/bytes_spec.gobra
@@ -1,0 +1,15 @@
+package bytes
+
+// +gobra
+
+import (
+	sl "verification/utils/slices"
+)
+
+ghost
+requires acc(sl.Bytes(ub, 0, len(ub)), _)
+ensures len(res) == len(ub)
+ensures forall i int :: { res[i] } 0 <= i && i < len(ub) ==>
+    res[i] == sl.GetByte(ub, 0, len(ub), i)
+decreases _
+pure func View(ub []byte) (res seq[byte])

--- a/src/bytes/bytes_spec.gobra
+++ b/src/bytes/bytes_spec.gobra
@@ -13,3 +13,29 @@ ensures forall i int :: { res[i] } 0 <= i && i < len(ub) ==>
     res[i] == sl.GetByte(ub, 0, len(ub), i)
 decreases _
 pure func View(ub []byte) (res seq[byte])
+
+// TODO: make this opaque
+ghost
+requires count >= 0
+decreases count
+pure func SpecRepeat(b seq[byte], count int) (res seq[byte]) {
+	return count == 0 ? seq[byte]{} : ( b ++ SpecRepeat(b, count - 1) )
+}
+
+
+ghost
+requires low <= high
+ensures res == exists i int :: {i in s} i in s && low <= i && i < high
+opaque
+decreases high - low
+pure func SetContainsInRange(s set[int], low, high int) (res bool) {
+	return low < high && (low in s || ( low < high && SetContainsInRange(s, low + 1, high) ))
+}
+
+// returns true if a == a0 ++ b ++ a1 for some a0, a1
+ghost
+requires 0 <= i && i + len(b) <= len(a)
+decreases
+pure func SubviewEq(a, b seq[byte], i int) (res bool) {
+	return a[i:i+len(b)] == b
+}

--- a/src/bytes/spec/bytes_spec.gobra
+++ b/src/bytes/spec/bytes_spec.gobra
@@ -22,6 +22,66 @@ pure func SpecRepeat(b seq[byte], count int) (res seq[byte]) {
 	return count == 0 ? seq[byte]{} : ( b ++ SpecRepeat(b, count - 1) )
 }
 
+ghost
+decreases _
+pure func SpecSplit(b, sep seq[byte]) (res seq[seq[byte]]) {
+	return SpecSplitInner(b, sep, seq[byte]{})
+}
+
+ghost
+decreases _
+pure func SpecSplitInner(s, sep, ac seq[byte]) (res seq[seq[byte]]) {
+	return len(s) == 0 ?
+		( len(ac) == 0 ?
+			seq[seq[byte]]{} :
+			seq[seq[byte]]{ac}) :
+		( sep == s ?
+			seq[seq[byte]]{ ac, seq[byte]{} } :
+			s[:len(sep)] == sep ?
+				seq[seq[byte]]{ac} ++ SpecSplitInner(s[len(sep):], sep, seq[byte]{}) :
+				SpecSplitInner(s[1:], sep, ac ++ seq[byte]{s[0]}))
+}
+
+ghost
+requires 0 < len(s)
+ensures 0 < len(SpecSplit(s, sep))
+decreases
+func LemmaSpecSplitNonEmpty(s, sep seq[byte]) {
+	lemmaSpecSplitInnerNonEmpty(s, sep, seq[byte]{})
+}
+
+ghost
+requires 0 < len(ac)
+ensures 0 < len(SpecSplitInner(s, sep, ac))
+decreases len(s)
+func lemmaSpecSplitInnerAcNonEmpty(s, sep, ac seq[byte]) {
+	switch {
+	case len(s) == 0:
+		assert len(SpecSplitInner(s, sep, ac)) == 1
+	case sep == s:
+		assert len(SpecSplitInner(s, sep, ac)) == 2
+	case s[:len(sep)] == sep:
+		assert len(SpecSplitInner(s, sep, ac)) >= 1
+	default:
+		lemmaSpecSplitInnerAcNonEmpty(s[1:], sep, ac ++ seq[byte]{s[0]})
+	}
+}
+
+ghost
+requires 0 < len(s)
+ensures 0 < len(SpecSplitInner(s, sep, ac))
+decreases
+func lemmaSpecSplitInnerNonEmpty(s, sep, ac seq[byte]) {
+	switch {
+	case sep == s:
+		assert len(SpecSplitInner(s, sep, ac)) == 2
+	case s[:len(sep)] == sep:
+		assert len(SpecSplitInner(s, sep, ac)) >= 1
+	default:
+		lemmaSpecSplitInnerAcNonEmpty(s[1:], sep, ac ++ seq[byte]{s[0]})
+	}
+}
+
 
 ghost
 requires low <= high

--- a/src/bytes/spec/bytes_spec.gobra
+++ b/src/bytes/spec/bytes_spec.gobra
@@ -1,4 +1,4 @@
-package bytes
+package spec
 
 // +gobra
 

--- a/src/container/list/list.go
+++ b/src/container/list/list.go
@@ -99,13 +99,13 @@ func New() (l *List) {
 
 // Len returns the number of elements of list l.
 // The complexity is O(1).
-//@ requires l.Mem(elems, isInit)
-//@ ensures  unfolding l.Mem(elems, isInit) in res == l.lenT
-//@ ensures  unfolding l.Mem(elems, isInit) in !isInit ==> res == 0
+//@ requires acc(l.Mem(elems, isInit), ReadPerm)
+//@ ensures  unfolding acc(l.Mem(elems, isInit), ReadPerm) in res == l.lenT
+//@ ensures  unfolding acc(l.Mem(elems, isInit), ReadPerm) in !isInit ==> res == 0
 //@ decreases
 //@ pure
 func (l *List) Len(/*@ ghost elems set[*Element], isInit bool @*/) (res int) {
-	return /*@ unfolding l.Mem(elems, isInit) in @*/ l.lenT
+	return /*@ unfolding acc(l.Mem(elems, isInit), ReadPerm) in @*/ l.lenT
 }
 
 // Front returns the first element of list l or nil if the list is empty.

--- a/src/container/list/list_spec.gobra
+++ b/src/container/list/list_spec.gobra
@@ -10,6 +10,7 @@ requires list.Mem(elems, true)
 requires e in elems
 ensures  res == (unfolding list.Mem(elems, true) in e.next)
 ensures  unfolding list.Mem(elems, true) in res in elems
+decreases _
 pure
 func (e *Element) nextPure(ghost elems set[*Element], ghost list *List) (res *Element) {
 	return unfolding list.Mem(elems, true) in e.next
@@ -20,6 +21,7 @@ requires list.Mem(elems, true)
 requires e in elems
 ensures  res == (unfolding list.Mem(elems, true) in e.prev)
 ensures  unfolding list.Mem(elems, true) in res in elems
+decreases _
 pure
 func (e *Element) prevPure(ghost elems set[*Element], ghost list *List) (res *Element) {
 	return unfolding list.Mem(elems, true) in e.prev
@@ -29,6 +31,7 @@ ghost
 requires l.Mem(elems, true)
 requires e1 in elems && e2 in elems
 ensures  unfolding l.Mem(elems, true) in (e1.next == e2 && e2.prev == e1) == res
+decreases _
 pure
 func (e1 *Element) comesBefore(e2 *Element, ghost elems set[*Element], ghost l *List) (res bool) {
 	return unfolding l.Mem(elems, true) in (e1.next == e2 && e2.prev == e1)

--- a/src/internal/bytealg/bytealg.gobra
+++ b/src/internal/bytealg/bytealg.gobra
@@ -21,11 +21,12 @@ const MaxBruteForce = 64
 func Cutover(n int) int
 
 requires 2 <= len(b) && len(b) <= MaxLen
-preserves acc(sl.Bytes(a, 0, len(a)), R40)
-preserves acc(sl.Bytes(b, 0, len(b)), R40)
+preserves acc(sl.Bytes(a, 0, len(a)), R45)
+preserves acc(sl.Bytes(b, 0, len(b)), R45)
 ensures 0 <= res && res + len(b) <= len(a)
 ensures res != -1 ==> View(a)[res:res+len(b)] == View(b)
 ensures res == -1 ==> !exists i int :: {View(a)[i:i+len(b)]} View(a)[i:i+len(b)] == View(b)
+ensures res != -1 ==> forall i int :: {View(a)[i:i+len(b)]} 0 <= i && i < res ==> View(a)[i:i+len(b)] != View(b)
 decreases _
 func Index(a, b []byte) (res int)
 
@@ -55,5 +56,6 @@ preserves acc(sl.Bytes(sep, 0, len(sep)), R50)
 ensures 0 <= res && res + len(sep) <= len(s)
 ensures res != -1 ==> View(s)[res:res+len(sep)] == View(sep)
 ensures res == -1 ==> !exists i int :: {View(s)[i:i+len(sep)]} View(s)[i:i+len(sep)] == View(sep)
+ensures res != -1 ==> forall i int :: {View(s)[i:i+len(sep)]} 0 <= i && i < res ==> View(s)[i:i+len(sep)] != View(sep)
 decreases _
 func IndexRabinKarpBytes(s, sep []byte) (res int)

--- a/src/internal/bytealg/bytealg.gobra
+++ b/src/internal/bytealg/bytealg.gobra
@@ -1,0 +1,54 @@
+package bytealg
+
+// +gobra
+
+import (
+	. "verification/utils/definitions"
+	sl "verification/utils/slices"
+	. "bytes/spec"
+)
+
+preserves acc(sl.Bytes(b, 0, len(b)), R50)
+ensures res >= 0
+ensures len(indices) == res
+ensures forall i int :: {i in indices} i in indices ==> 0 <= i && i < len(b)
+ensures forall i int :: {i in indices} i in indices ==> ( sl.GetByte(b, 0, len(b), i) == c)
+ensures forall i int :: {i in indices} !(i in indices) ==> ( i < 0 || len(b) <= i || sl.GetByte(b, 0, len(b), i) != c)
+func Count(b []byte, c byte) (res int , ghost indices set[int])
+
+const MaxBruteForce = 64
+func Cutover(n int) int
+
+requires 2 <= len(b) && len(b) <= MaxLen
+preserves acc(sl.Bytes(a, 0, len(a)), R40)
+preserves acc(sl.Bytes(b, 0, len(b)), R40)
+ensures 0 <= res && res + len(b) <= len(a)
+ensures res != -1 ==> View(a)[res:res+len(b)] == View(b)
+ensures res == -1 ==> !exists i int :: {View(a)[i:i+len(b)]} View(a)[i:i+len(b)] == View(b)
+func Index(a, b []byte) (res int)
+
+func IndexString(a, b string) int
+
+preserves acc(sl.Bytes(b, 0, len(b)), R50)
+ensures 0 <= res && res < len(b)
+ensures res != -1 == ((forall i int :: {View(b)[i]} 0 <= i && i < res ==> View(b)[i] != c) && View(b)[res] == c)
+ensures res == -1 == (forall i int :: {View(b)[i]} 0 <= i && i < len(b) ==> View(b)[i] != c)
+func IndexByte(b []byte, c byte) (res int)
+func IndexByteString(s string, c byte) int
+
+preserves acc(sl.Bytes(a, 0, len(a)), R40)
+preserves acc(sl.Bytes(b, 0, len(b)), R40)
+func Compare(a, b []byte) int
+
+var MaxLen int
+
+const PrimeRK = 16777619
+
+func HashStrRevBytes(sep []byte) (uint32, uint32)
+
+preserves acc(sl.Bytes(s, 0, len(s)), R50)
+preserves acc(sl.Bytes(sep, 0, len(sep)), R50)
+ensures 0 <= res && res + len(sep) <= len(s)
+ensures res != -1 ==> View(s)[res:res+len(sep)] == View(sep)
+ensures res == -1 ==> !exists i int :: {View(s)[i:i+len(sep)]} View(s)[i:i+len(sep)] == View(sep)
+func IndexRabinKarpBytes(s, sep []byte) (res int)

--- a/src/internal/bytealg/bytealg.gobra
+++ b/src/internal/bytealg/bytealg.gobra
@@ -14,6 +14,7 @@ ensures len(indices) == res
 ensures forall i int :: {i in indices} i in indices ==> 0 <= i && i < len(b)
 ensures forall i int :: {i in indices} i in indices ==> ( sl.GetByte(b, 0, len(b), i) == c)
 ensures forall i int :: {i in indices} !(i in indices) ==> ( i < 0 || len(b) <= i || sl.GetByte(b, 0, len(b), i) != c)
+decreases _
 func Count(b []byte, c byte) (res int , ghost indices set[int])
 
 const MaxBruteForce = 64
@@ -25,6 +26,7 @@ preserves acc(sl.Bytes(b, 0, len(b)), R40)
 ensures 0 <= res && res + len(b) <= len(a)
 ensures res != -1 ==> View(a)[res:res+len(b)] == View(b)
 ensures res == -1 ==> !exists i int :: {View(a)[i:i+len(b)]} View(a)[i:i+len(b)] == View(b)
+decreases _
 func Index(a, b []byte) (res int)
 
 func IndexString(a, b string) int
@@ -33,11 +35,13 @@ preserves acc(sl.Bytes(b, 0, len(b)), R50)
 ensures 0 <= res && res < len(b)
 ensures res != -1 == ((forall i int :: {View(b)[i]} 0 <= i && i < res ==> View(b)[i] != c) && View(b)[res] == c)
 ensures res == -1 == (forall i int :: {View(b)[i]} 0 <= i && i < len(b) ==> View(b)[i] != c)
+decreases _
 func IndexByte(b []byte, c byte) (res int)
 func IndexByteString(s string, c byte) int
 
 preserves acc(sl.Bytes(a, 0, len(a)), R40)
 preserves acc(sl.Bytes(b, 0, len(b)), R40)
+decreases _
 func Compare(a, b []byte) int
 
 var MaxLen int
@@ -51,4 +55,5 @@ preserves acc(sl.Bytes(sep, 0, len(sep)), R50)
 ensures 0 <= res && res + len(sep) <= len(s)
 ensures res != -1 ==> View(s)[res:res+len(sep)] == View(sep)
 ensures res == -1 ==> !exists i int :: {View(s)[i:i+len(sep)]} View(s)[i:i+len(sep)] == View(sep)
+decreases _
 func IndexRabinKarpBytes(s, sep []byte) (res int)

--- a/src/internal/bytealg/bytealg.gobra
+++ b/src/internal/bytealg/bytealg.gobra
@@ -14,10 +14,14 @@ ensures len(indices) == res
 ensures forall i int :: {i in indices} i in indices ==> 0 <= i && i < len(b)
 ensures forall i int :: {i in indices} i in indices ==> ( sl.GetByte(b, 0, len(b), i) == c)
 ensures forall i int :: {i in indices} !(i in indices) ==> ( i < 0 || len(b) <= i || sl.GetByte(b, 0, len(b), i) != c)
-decreases _
+trusted
+decreases
 func Count(b []byte, c byte) (res int , ghost indices set[int])
 
 const MaxBruteForce = 64
+
+trusted
+decreases
 func Cutover(n int) int
 
 requires 2 <= len(b) && len(b) <= MaxLen
@@ -27,7 +31,8 @@ ensures 0 <= res && res + len(b) <= len(a)
 ensures res != -1 ==> View(a)[res:res+len(b)] == View(b)
 ensures res == -1 ==> !exists i int :: {View(a)[i:i+len(b)]} View(a)[i:i+len(b)] == View(b)
 ensures res != -1 ==> forall i int :: {View(a)[i:i+len(b)]} 0 <= i && i < res ==> View(a)[i:i+len(b)] != View(b)
-decreases _
+trusted
+decreases
 func Index(a, b []byte) (res int)
 
 func IndexString(a, b string) int
@@ -36,19 +41,25 @@ preserves acc(sl.Bytes(b, 0, len(b)), R50)
 ensures 0 <= res && res < len(b)
 ensures res != -1 == ((forall i int :: {View(b)[i]} 0 <= i && i < res ==> View(b)[i] != c) && View(b)[res] == c)
 ensures res == -1 == (forall i int :: {View(b)[i]} 0 <= i && i < len(b) ==> View(b)[i] != c)
-decreases _
+trusted
+decreases
 func IndexByte(b []byte, c byte) (res int)
+trusted
+decreases
 func IndexByteString(s string, c byte) int
 
 preserves acc(sl.Bytes(a, 0, len(a)), R40)
 preserves acc(sl.Bytes(b, 0, len(b)), R40)
-decreases _
+trusted
+decreases
 func Compare(a, b []byte) int
 
 var MaxLen int
 
 const PrimeRK = 16777619
 
+trusted
+decreases
 func HashStrRevBytes(sep []byte) (uint32, uint32)
 
 preserves acc(sl.Bytes(s, 0, len(s)), R50)
@@ -57,5 +68,6 @@ ensures 0 <= res && res + len(sep) <= len(s)
 ensures res != -1 ==> View(s)[res:res+len(sep)] == View(sep)
 ensures res == -1 ==> !exists i int :: {View(s)[i:i+len(sep)]} View(s)[i:i+len(sep)] == View(sep)
 ensures res != -1 ==> forall i int :: {View(s)[i:i+len(sep)]} 0 <= i && i < res ==> View(s)[i:i+len(sep)] != View(sep)
-decreases _
+trusted
+decreases
 func IndexRabinKarpBytes(s, sep []byte) (res int)

--- a/src/path/path.go
+++ b/src/path/path.go
@@ -11,41 +11,154 @@
 // operating system paths, use the path/filepath package.
 package path
 
+// @ import (
+// @	. "verification/utils/definitions"
+// @	sl "verification/utils/slices"
+// @	seqs "verification/utils/seqs"
+// @	sets "verification/utils/sets"
+// @	bytes "bytes/spec"
+// @ )
+
+// +gobra
+
+type string_byte = []byte
+
 // A lazybuf is a lazily constructed path buffer.
 // It supports append, reading previously appended bytes,
 // and retrieving the final string. It does not allocate a buffer
 // to hold the output until that output diverges from s.
 type lazybuf struct {
-	s   string
+	s   string_byte
 	buf []byte
 	w   int
 }
 
-func (b *lazybuf) index(i int) byte {
+// @ requires acc(Lazybuf(b, R41), R50)
+// @ requires InRange(i, 0, len(getS(b)))
+// @ ensures acc(Lazybuf(b, R41), R50)
+// @ ensures InRange(i, 0, len(getS(b)))
+// @ ensures b.specIndex(i) == res
+func (b *lazybuf) index(i int) (res byte) {
+	// @ unfold acc(Lazybuf(b, R41), R50)
+	// @ defer fold acc(Lazybuf(b, R41), R50)
 	if b.buf != nil {
+		// @ unfold acc(sl.Bytes(b.buf, 0, len(b.buf)), R45*R50)
+		// @ defer fold acc(sl.Bytes(b.buf, 0, len(b.buf)), R45*R50)
 		return b.buf[i]
 	}
+	// @ unfold acc(sl.Bytes(b.s, 0, len(b.s)), R41*R50)
+	// @ defer fold acc(sl.Bytes(b.s, 0, len(b.s)), R41*R50)
 	return b.s[i]
 }
 
+// @ requires Lazybuf(b, R41)
+//
+// @ requires lazybufInvariant(b)
+//
+// @ requires getW(b) < len(getS(b))
+//
+// @ ensures Lazybuf(b, R41)
+//
+// @ ensures old(getW(b)) + 1 == getW(b)
+//
+// @ ensures lazybufInvariant(b)
+//
+// @ ensures old(getS(b)) == getS(b)
+//
+// @ ensures 1 <= len(getValue(b))
+//
+// @ ensures lastByte(getValue(b)) == c
+//
+// @ ensures getValue(b) == old(getValue(b)) ++ seq[byte]{ c }
 func (b *lazybuf) append(c byte) {
+	// @ unfold Lazybuf(b, R41)
 	if b.buf == nil {
+		// @ unfold acc(sl.Bytes(b.s, 0, len(b.s)), R45)
+		// @ assert forall i int :: { &b.s[i] } 0 <= i && i < len(b.s) ==> acc(&b.s[i], R45)
+		// @ assert b.w < len(b.s) ==> acc(&b.s[b.w], R45)
+		// @ val := b.s[b.w]
 		if b.w < len(b.s) && b.s[b.w] == c {
 			b.w++
+			// @ fold acc(sl.Bytes(b.s, 0, len(b.s)), R45)
+			// @ fold Lazybuf(b, R41)
+			// @ assert (getS(b)[:getW(b)] == getValue(b)) ==
+			// @	unfolding Lazybuf(b, R41) in b.buf == nil
+			// @ assert lastByte(getValue(b)) == c
+			// @ assert getValue(b) == old(getValue(b)) ++ seq[byte]{ c }
 			return
 		}
 		b.buf = make([]byte, len(b.s))
-		copy(b.buf, b.s[:b.w])
+		// @ assert len(b.s) > 0
+		// @ assert 0 < len(b.buf)
+		// @ assert b.buf != nil
+		// @ SubSliceOverlaps(b.s, 0, b.w)
+		copy(b.buf, b.s[:b.w] /* @ , R45 @ */)
+		// @ fold acc(sl.Bytes(b.s, 0, len(b.s)), R45)
+		// @ fold sl.Bytes(b.buf, 0, len(b.buf))
+		// @ fold Lazybuf(b, R41)
+		// @ assert !bufIsEmpty(b)
+		// @ assert getS(b)[:getW(b) + 1] == getS(b)[:getW(b)] ++ seq[byte]{ val }
+		// @ assert val != c
+		// @ lemmaSlicesIneqLastElem(getS(b)[:getW(b)], getValue(b), val, c)
+		// @ assert getS(b)[:getW(b)] ++ seq[byte]{ val } != getValue(b) ++ seq[byte]{c}
+		// @ assert getS(b)[:getW(b) + 1] != getValue(b) ++ seq[byte]{c}
+		// @ unfold Lazybuf(b, R41)
 	}
+	// @ fold Lazybuf(b, R41)
+	// @ ghost w := getW(b)
+	// @ ghost oldval := getValue(b)
+
+	// @ requires Lazybuf(b, R41)
+	// @ requires getW(b) < len(getS(b))
+	// @ requires unfolding Lazybuf(b, R41) in b.buf != nil
+	// @ ensures Lazybuf(b, R41)
+	// @ ensures getW(b) == before(getW(b)) + 1
+	// @ ensures lazybufInvariant(b)
+	// @ ensures before(getS(b)) == getS(b)
+	// @ ensures lastByte(getValue(b)) == c
+	// @ ensures getValue(b) == before(getValue(b)) ++ seq[byte]{ c }
+	// @ decreases
+	// @ outline (
+
+	// @ unfold Lazybuf(b, R41)
+	// @ assert bytes.View(b.s)[:b.w+1] != bytes.View(b.buf)[:b.w]
+	// @ assert b.buf != nil
+	// @ assert len(b.buf) == len(b.s)
+	// @ assert b.w < len(b.s)
+	// @ assert InRangeInc(b.w, 0, len(b.buf))
+	// @ unfold sl.Bytes(b.buf, 0, len(b.buf))
+	// @ assert InRange(b.w, 0, len(b.buf))
 	b.buf[b.w] = c
+	// @ fold sl.Bytes(b.buf, 0, len(b.buf))
 	b.w++
+	// @ fold Lazybuf(b, R41)
+	// @ assert lastByte(getValue(b)) == c
+	// @ )
 }
 
-func (b *lazybuf) string() string {
+// @ requires Lazybuf(b, R41)
+// @ ensures acc(sl.Bytes(res, 0, len(res)), R41)
+// @ ensures bytes.View(res) == old(getValue(b))
+func (b *lazybuf) string() (res string_byte) {
+	// @ unfold Lazybuf(b, R41)
 	if b.buf == nil {
-		return b.s[:b.w]
+		//gobra:rewrite 55a9058f66d7ec4eb7dcedbcb81150100fed02eb056ec592fa972a8b7c4d282d
+		//gobra:cont 		return b.s[:b.w]
+		//gobra:end-old-code 55a9058f66d7ec4eb7dcedbcb81150100fed02eb056ec592fa972a8b7c4d282d
+		// @ unfold acc(sl.Bytes(b.s, 0, len(b.s)), R41)
+		res = b.s[:b.w]
+		// @ fold acc(sl.Bytes(res, 0, len(res)), R41)
+		return res
+		//gobra:endrewrite 55a9058f66d7ec4eb7dcedbcb81150100fed02eb056ec592fa972a8b7c4d282d
 	}
-	return string(b.buf[:b.w])
+	//gobra:rewrite cbf2c42ce1e10c57fe0cb16664da45e809fec83320ddc61ef3bdc35af5e2ddd6
+	//gobra:cont 	return string_byte(b.buf[:b.w])
+	//gobra:end-old-code cbf2c42ce1e10c57fe0cb16664da45e809fec83320ddc61ef3bdc35af5e2ddd6
+	// @ unfold acc(sl.Bytes(b.buf, 0, len(b.buf)), R41)
+	res = string_byte(b.buf[:b.w])
+	// @ fold acc(sl.Bytes(res, 0, len(res)), R41)
+	return res
+	//gobra:endrewrite cbf2c42ce1e10c57fe0cb16664da45e809fec83320ddc61ef3bdc35af5e2ddd6
 }
 
 // Clean returns the shortest path name equivalent to path
@@ -67,12 +180,35 @@ func (b *lazybuf) string() string {
 // See also Rob Pike, “Lexical File Names in Plan 9 or
 // Getting Dot-Dot Right,”
 // https://9p.io/sys/doc/lexnames.html
-func Clean(path string) string {
-	if path == "" {
-		return "."
-	}
+//
+// @ requires acc(sl.Bytes(path, 0, len(path)), R40)
+//
+// @ ensures acc(sl.Bytes(path, 0, len(path)), R41)
+//
+// @ ensures acc( sl.Bytes(res, 0, len(res)), R41 )
+//
+// @ ensures SpecClean(ToPath(bytes.View(path))) == ToPath(bytes.View(res))
+func Clean(path string_byte) (res string_byte) {
+	//gobra:rewrite 70493558394bddd26fc4913b3282a2fc8d74fce232cdd1932ae5fad203b0798b
+	//gobra:cont 	if path == "" {
+	//gobra:cont 		return "."
+	//gobra:cont 	}
+	//gobra:end-old-code 70493558394bddd26fc4913b3282a2fc8d74fce232cdd1932ae5fad203b0798b
+	if len(path) == 0 {
+		res = string_byte{'.'}
+		// @ fold sl.Bytes(res, 0, len(res))
+		// @ lemmaToPathDot(bytes.View(res))
 
+		// @ assert SpecClean(ToPath(bytes.View(path))) == ToPath(bytes.View(res))
+		// @ assert acc( sl.Bytes(res, 0, len(res)), R41 )
+		return res
+	}
+	//gobra:endrewrite 70493558394bddd26fc4913b3282a2fc8d74fce232cdd1932ae5fad203b0798b
+
+	// @ unfold acc(sl.Bytes(path, 0, len(path)), R41)
 	rooted := path[0] == '/'
+	// @ fold   acc(sl.Bytes(path, 0, len(path)), R41)
+	// @ assert acc(sl.Bytes(path, 0, len(path)), R40)
 	n := len(path)
 
 	// Invariants:
@@ -80,67 +216,333 @@ func Clean(path string) string {
 	//	writing to buf; w is index of next byte to write.
 	//	dotdot is index in buf where .. must stop, either because
 	//		it is the leading slash or it is a leading ../../.. prefix.
-	out := lazybuf{s: path}
+	out /* @@@ */ := lazybuf{s: path}
+	// @ fold sl.Bytes(out.buf, 0, len(out.buf))
+	// @ fold Lazybuf(&out, R41)
+	// @ assert Lazybuf(&out, R41)
+	// @ assert unfolding Lazybuf(&out, R41) in len(out.s) == n
+	// @ assert unfolding Lazybuf(&out, R41) in len(bytes.View(out.s)) == n
+	// @ assert len(getS(&out)) == n
+	// @ assert n == len(getS(&out))
 	r, dotdot := 0, 0
 	if rooted {
+		// @ assert len(getValue(&out)) == 0
 		out.append('/')
+		// @ assert len(getValue(&out)) == getW(&out)
+		// @ assert len(getValue(&out)) == 1
+		// @ assert getValue(&out)[0] == '/'
+		// @ assert unfolding Lazybuf(&out, R41) in 1 <= out.w
 		r, dotdot = 1, 1
+		// @ assert InRangeInc(dotdot, 0, len(getValue(&out)))
 	}
+	// @ assert n == len(getS(&out))
+	// @ assert rooted ==> unfolding Lazybuf(&out, R41) in InRangeInc(out.w, 1, n)
+	// @ assert InRangeInc(dotdot, 0, len(getValue(&out)))
+	// @ assert getW(&out) == startIndex(rooted)
 
+	// @ invariant InRangeInc(r, 0, n)
+	// @ invariant Lazybuf(&out, R41)
+	// @ invariant lazybufInvariant(&out)
+	// @ invariant dotdotInvariant(dotdot, rooted, getValue(&out))
+	// @ invariant getW(&out) <= r
+	// @ invariant (rooted ? 1 : 0) <= dotdot
+	// @ invariant rooted ==> unfolding Lazybuf(&out, R41) in InRangeInc(out.w, 0, n)
+	// @ invariant n == len(getS(&out))
+	// @ invariant acc(sl.Bytes(path, 0, len(path)), R41)
+	// @ invariant !rooted ==> bytes.View(path)[0] != '/'
+	// @ invariant rooted ==> 1 <= len(getValue(&out)) && getValue(&out)[0] == '/'
+	// @ invariant !rooted && 1 <= len(getValue(&out)) ==> getValue(&out)[0] != '/'
+	// @ invariant isCompleted(bytes.View(path)[:r]) || willBeCompleted(bytes.View(path), r)
+	// @ invariant noTrailingSlash(getValue(&out), rooted)
+	// @ invariant noDoubleSlash(getValue(&out))
+	// @ invariant readingIsAheadOfWriting(bytes.View(path), getW(&out), r, rooted)
+	// @ invariant SpecClean(ToPath(bytes.View(path)[:r] )) == ToPath( getValue(&out) )
 	for r < n {
+		// @ unfold acc(sl.Bytes(path, 0, len(path)), R45)
 		switch {
 		case path[r] == '/':
 			// empty path element
 			r++
+			// @ assert rooted ==> 1 <= len(getValue(&out)) && getValue(&out)[0] == '/'
+			// @ assert noTrailingSlash(getValue(&out), rooted)
+			// # assert noIncompleteRead(bytes.View(path), r, rooted)
+			// @ assert noDoubleSlash(getValue(&out))
+			// @ assert readingIsAheadOfWriting(bytes.View(path), getW(&out), r, rooted)
+			// @ lemmaToPathAppendingSlash(
+			// @	ToPath(bytes.View(path)[:r-1] ),
+			// @	bytes.View(path)[:r-1],
+			// @ )
+			// @ assert SpecClean(ToPath(bytes.View(path)[:r] )) == ToPath( getValue(&out) )
+			// @ assert isCompleted(bytes.View(path)[:r])
 		case path[r] == '.' && (r+1 == n || path[r+1] == '/'):
 			// . element
 			r++
+			// @ assert rooted ==> 1 <= len(getValue(&out)) && getValue(&out)[0] == '/'
+			// @ assert noTrailingSlash(getValue(&out), rooted)
+
+			// # assert noIncompleteRead(bytes.View(path), r, rooted)
+			// @ assert noDoubleSlash(getValue(&out))
+			// @ assert readingIsAheadOfWriting(bytes.View(path), getW(&out), r, rooted)
+			// @ assert willBeCompleted(bytes.View(path), r)
 		case path[r] == '.' && path[r+1] == '.' && (r+2 == n || path[r+2] == '/'):
 			// .. element: remove to last /
+			// @ assert !(path[r] == '.' && (r+1 == n || path[r+1] == '/'))
+			// @ assert !(r+1 == n || path[r+1] == '/')
+			// @ assert !(r+1 == n)
+			// @ assert isCompleted(bytes.View(path)[:r])
 			r += 2
+			// @ assert willBeCompleted(bytes.View(path), r)
+			// @ assert r <= n
+			// @ assert getW(&out)+2 <= r
+			// @ assert lazybufInvariant(&out)
+			// @ assert noDoubleSlash(getValue(&out))
+			// @ unfold Lazybuf(&out, R41)
+			// @ assert InRangeInc(out.w, 0, len(out.s))
 			switch {
 			case out.w > dotdot:
 				// can backtrack
+				// @ assert 0 < out.w
+
+				// @ fold Lazybuf(&out, R41)
+				// @ ghost prev := getValue(&out)
+				// @ ghost origW := getW(&out)
+				// @ assert SpecClean(ToPath(bytes.View(path)[:r] )) == ToPath( getValue(&out) )
+				// @ ghost prevPath := ToPath(getValue(&out))
+				// @ lemmaToPathNonEmpty(getValue(&out))
+				// @ ghost reducedPath := Path { rooted: prevPath.rooted, parts: prevPath.dirname() }
+				// @ ghost ch := lastByte(getValue(&out))
+				// @ lemmaNoTrailingSlashPath(getValue(&out), rooted)
+				// @ assert len(prevPath.parts) == len(reducedPath.parts) + 1
+				// @ assert len(prevPath.basename()) != 0
+				// @ unfold Lazybuf(&out, R41)
+
+				// @ assert InRangeInc(out.w, 1, len(out.s))
 				out.w--
-				for out.w > dotdot && out.index(out.w) != '/' {
+				// @ fold Lazybuf(&out, R41)
+				// @ assert prev[:len(prev)-1] == getValue(&out)
+				// @ assert noDoubleSlash(getValue(&out))
+				// @ assert lazybufInvariant(&out)
+
+				//gobra:rewrite 30e2737508b727f0d5dfa371555f9b954bf541ea0deccbcda2841807f6db60bb
+				//gobra:cont 				for /* @ ( unfolding Lazybuf(&out, R41) in @ */ out.w /* @)@ */ > dotdot && out.index( /* @ unfolding Lazybuf(&out, R41) in @ */ out.w) != '/' {
+				//gobra:end-old-code 30e2737508b727f0d5dfa371555f9b954bf541ea0deccbcda2841807f6db60bb
+				// see gobra issue #794
+				cond := /* @ ( unfolding Lazybuf(&out, R41) in @ */ out.w /* @)@ */ > dotdot && out.index( /* @ unfolding Lazybuf(&out, R41) in @ */ out.w) != '/'
+				// @ invariant Lazybuf(&out, R41)
+				// @ invariant acc(sl.Bytes(path, 0, len(path)), R50)
+				// @ invariant 0 <= dotdot
+				// @ invariant r <= n
+				// @ invariant n == len(getS(&out))
+				// @ invariant getW(&out)+1 <= r
+				// @ invariant getW(&out) >= dotdot
+				// @ invariant rooted ==> 1 <= len(getValue(&out)) && getValue(&out)[0] == '/'
+				// @ invariant lazybufInvariant(&out)
+
+				// @ invariant dotdotInvariant(dotdot, rooted, getValue(&out))
+				// @ invariant noDoubleSlash(getValue(&out))
+				// @ invariant prev[:origW] == out.valueUntrimmed()[:origW]
+				// @ invariant getW(&out) < origW
+				// @ invariant len(getValue(&out)) < len(prev)
+				// @ invariant cond == (getW(&out) > dotdot && out.specIndex(getW(&out)) != '/')
+
+				// @ invariant readingIsAheadOfWriting(bytes.View(path), getW(&out), r, rooted)
+				// @ invariant len(ToPath(out.valueUntrimmed()[:getW(&out)+1]).parts) > 0
+				// @ invariant ToPath(out.valueUntrimmed()[:getW(&out)+1]).dirname() == reducedPath.parts
+				for cond {
+					//gobra:endrewrite 30e2737508b727f0d5dfa371555f9b954bf541ea0deccbcda2841807f6db60bb
+					// @ ghost prev := getValue(&out)
+					// @ ghost ch := out.specIndex(getW(&out))
+					// @ assert out.valueUntrimmed()[:getW(&out)+1] == prev ++ seq[byte]{ch}
+					// @ assert out.specIndex(getW(&out)) != '/'
+					// @ assert out.specIndex(getW(&out)) != '/'
+					// @ assert ch != '/'
+					// @ unfold Lazybuf(&out, R41)
+					// @ lemmaLeqTransitive(0, dotdot, out.w - 1)
 					out.w--
+					// @ fold Lazybuf(&out, R41)
+					// @ assert prev[:len(prev)-1] == getValue(&out)
+					// @ lemmaToPathPoppingNormalChar(prev, ch)
+					//gobra:rewrite 4dc76020bae70577e64b330dca83fdf24f3d7593a0154d8abec6dc63f5897fd9
+					//gobra:cont 				}
+					//gobra:end-old-code 4dc76020bae70577e64b330dca83fdf24f3d7593a0154d8abec6dc63f5897fd9
+					cond = /* @ ( unfolding Lazybuf(&out, R41) in @ */ out.w /* @)@ */ > dotdot && out.index( /* @ unfolding Lazybuf(&out, R41) in @ */ out.w) != '/'
 				}
+				//gobra:endrewrite 4dc76020bae70577e64b330dca83fdf24f3d7593a0154d8abec6dc63f5897fd9
+			/* @
+
+			ghost w := getW(&out)
+			ghost if w <= dotdot {
+				assert w == dotdot
+				ghost if dotdot == (rooted ? 1 : 0) {
+					assert len(getValue(&out)) == (rooted ? 1 : 0)
+					assert noTrailingSlash(getValue(&out), rooted)
+				} else {
+					assert getValue(&out)[dotdot-1] != '/'
+				}
+				assert noTrailingSlash(getValue(&out), rooted)
+			} else {
+				assert out.specIndex(w) == '/'
+				ghost value := getValue(&out)
+				ghost v := out.valueUntrimmed()
+				assert out.valueUntrimmed()[w] == '/'
+				assert prev[:origW] == out.valueUntrimmed()[:origW]
+				assert w < origW
+				assert len(value) < len(prev)
+				assert prev[:w] == value
+				assert noDoubleSlash(prev)
+				assert prev[w] == '/'
+				ghost if len(getValue(&out)) != (rooted ? 1 : 0) {
+					assert v[w] == '/'
+					lemmaNoTrailingSlash(prev, w, rooted)
+				}
+
+				assert noTrailingSlash(getValue(&out), rooted)
+			}
+			@ */
+			// @ assert lazybufInvariant(&out)
+			// @ assert getW(&out) <= r
+			// @ assert n == len(getS(&out))
+			// @ assert noTrailingSlash(getValue(&out), rooted)
+			// @ assert dotdotInvariant(dotdot, rooted, getValue(&out))
+			// @ assert getW(&out) != (rooted ? 1 : 0) ==> getW(&out) < r
+			// @ lemmaToPathAppendingDotdot(
+			// @   ToPath(bytes.View(path)[:r-2] ),
+			// @   bytes.View(path)[:r-2],
+			// @ )
+
+			// @ assert SpecClean(ToPath(bytes.View(path)[:r] )) == ToPath( getValue(&out) )
+			// @ unfold Lazybuf(&out, R41)
 			case !rooted:
 				// cannot backtrack, but not rooted, so append .. element.
+				// @ assert out.w + 2 <= r
 				if out.w > 0 {
+					// @ fold Lazybuf(&out, R41)
 					out.append('/')
+					// @ unfold Lazybuf(&out, R41)
 				}
+				// @ fold Lazybuf(&out, R41)
 				out.append('.')
 				out.append('.')
+				// @ assert !rooted && 1 <= len(getValue(&out)) ==> getValue(&out)[0] != '/'
+				// @ unfold Lazybuf(&out, R41)
 				dotdot = out.w
 			}
+			// @ fold Lazybuf(&out, R41)
+			// @ assert !rooted && 1 <= len(getValue(&out)) ==> getValue(&out)[0] != '/'
+			// @ assert dotdotInvariant(dotdot, rooted, getValue(&out))
+			// @ assert n == len(getS(&out))
+			// @ assert rooted ==> 1 <= len(getValue(&out)) && getValue(&out)[0] == '/'
+			// @ assert noTrailingSlash(getValue(&out), rooted)
+			// @ assert noDoubleSlash(getValue(&out))
+			// @ assert readingIsAheadOfWriting(bytes.View(path), getW(&out), r, rooted)
 		default:
 			// real path element.
 			// add slash if needed
+			// @ assert getW(&out) <= r
+			// @ assert rooted ==> 1 <= len(getValue(&out)) && getValue(&out)[0] == '/'
+			// @ unfold Lazybuf(&out, R41)
 			if rooted && out.w != 1 || !rooted && out.w != 0 {
+				/* @
+				ghost if rooted {
+					assert out.w != 1
+					assert r < n
+					assert r <= n-1
+					assert out.w <= r
+					assert out.w <= n-1
+					assert n == len(out.s)
+					assert out.w < len(out.s)
+				} else {
+					assert out.w != 0
+					// assert out.buf != nil
+					assert n == len(out.s)
+					assert out.w < len(out.s)
+				}
+				@ */
+				// @ fold Lazybuf(&out, R41)
+				// @ assert rooted ==> 1 <= len(getValue(&out)) && getValue(&out)[0] == '/'
+				// @ assert len(getValue(&out)) == getW(&out)
 				out.append('/')
+				// @ assert getW(&out) <= r
+				// @ assert len(getValue(&out)) == getW(&out)
+				// @ assert rooted ==> 1 <= len(getValue(&out)) && getValue(&out)[0] == '/'
+				// @ unfold Lazybuf(&out, R41)
 			}
+			// @ fold Lazybuf(&out, R41)
+			// @ ghost origR := r
+			// @ ghost offset := r - getW(&out)
+			// @ assert getW(&out) <= r
+			// @ assert getW(&out) <= r+1
+			// @ assert r+1 <= n
+			// @ assert r < n && path[r] != '/'
 			// copy element
+			// @ invariant InRangeInc(r, 0, n)
+			// @ invariant Lazybuf(&out, R41)
+			// @ invariant getW(&out) <= r
+			// @ invariant n == len(getS(&out))
+			// @ invariant lazybufInvariant(&out)
+			// @ invariant forall i int :: {&path[i]} 0 <= i && i < len(path) ==> acc(&path[i], R50)
+			// @ invariant rooted ==> 1 <= len(getValue(&out)) && getValue(&out)[0] == '/'
+			// @ invariant r != origR ==> noTrailingSlash(getValue(&out), rooted)
+			// @ invariant dotdotInvariant(dotdot, rooted, getValue(&out))
+			// @ invariant noDoubleSlash(getValue(&out))
+			// @ invariant !rooted && 1 <= len(getValue(&out)) ==> getValue(&out)[0] != '/'
+			// @ decreases n - r
 			for ; r < n && path[r] != '/'; r++ {
+				// @ lemmaLeqTransitive(getW(&out), r, n-1)
 				out.append(path[r])
 			}
+			// @ assert readingIsAheadOfWriting(bytes.View(path), getW(&out), r, rooted)
+			// @ assert r >= n || path[r] == '/'
+			// @ assert isCompleted(bytes.View(path)[:r]) || willBeCompleted(bytes.View(path), r)
 		}
+		// @ fold acc(sl.Bytes(path, 0, len(path)), R45)
+
+		// @ assert acc(sl.Bytes(path, 0, len(path)), R41)
 	}
+	// @ assert acc(sl.Bytes(path, 0, len(path)), R41)
 
 	// Turn empty string into "."
+	// @ assert acc(sl.Bytes(path, 0, len(path)), R41)
+	// @ unfold Lazybuf(&out, R41)
 	if out.w == 0 {
-		return "."
+		// @ assert R41 + R41 == R40
+		//gobra:rewrite 7217a0df192ee4c8dace6a1956998718431158b18202a1c4e6de8921479f6bd3
+		//gobra:cont 		return "."
+		//gobra:end-old-code 7217a0df192ee4c8dace6a1956998718431158b18202a1c4e6de8921479f6bd3
+		// @ axiomStringByteAcc(path)
+		res = string_byte{'.'}
+		// @ fold acc(sl.Bytes(res, 0, len(res)), R40)
+		// @ assert SpecClean(ToPath(bytes.View(path))) == ToPath(bytes.View(res))
+		// @ assert acc(sl.Bytes(res, 0, len(res)), R41)
+		return res
+		//gobra:endrewrite 7217a0df192ee4c8dace6a1956998718431158b18202a1c4e6de8921479f6bd3
 	}
+	// @ fold Lazybuf(&out, R41)
 
-	return out.string()
+	//gobra:rewrite f5aa2c6509b2590f5eae382906e321f379502f39d2bd978429ef7b985350ce06
+	//gobra:cont 	return out.string()
+	//gobra:end-old-code f5aa2c6509b2590f5eae382906e321f379502f39d2bd978429ef7b985350ce06
+	res = out.string()
+	// @ assert acc(sl.Bytes(res, 0, len(res)), R41)
+	// @ assert SpecClean(ToPath(bytes.View(path))) == ToPath(bytes.View(res))
+	return res
+	//gobra:endrewrite f5aa2c6509b2590f5eae382906e321f379502f39d2bd978429ef7b985350ce06
 }
 
 // lastSlash(s) is strings.LastIndex(s, "/") but we can't import strings.
-func lastSlash(s string) int {
+// @ preserves acc(sl.Bytes(s, 0, len(s)), R50)
+// @ ensures InRange(res, -1, len(s))
+// @ decreases
+func lastSlash(s string_byte) (res int) {
 	i := len(s) - 1
+	// @ unfold acc(sl.Bytes(s, 0, len(s)), R50)
+	// @ invariant InRange(i, -1, len(s))
+	// @ invariant forall i int :: {&s[i]} 0 <= i && i < len(s) ==> acc(&s[i], R50)
+	// @ decreases i
 	for i >= 0 && s[i] != '/' {
 		i--
 	}
+	// @ fold acc(sl.Bytes(s, 0, len(s)), R50)
 	return i
 }
 
@@ -149,9 +551,25 @@ func lastSlash(s string) int {
 // If there is no slash in path, Split returns an empty dir and
 // file set to path.
 // The returned values have the property that path = dir+file.
-func Split(path string) (dir, file string) {
+// @ requires acc(sl.Bytes(path, 0, len(path)), R40)
+// @ ensures acc(sl.Bytes(path, 0, len(path)), R41)
+// @ ensures acc(sl.Bytes(dir, 0, len(dir)), R41)
+// @ ensures acc(sl.Bytes(file, 0, len(file)), R41)
+// @ decreases
+func Split(path string_byte) (dir, file string_byte) {
 	i := lastSlash(path)
-	return path[:i+1], path[i+1:]
+	//gobra:rewrite 04ab994e84db0990f91b85600e4e43ef0bfd1fd0cabfef3b1c509860ace6cc65
+	//gobra:cont 	return path[:i+1], path[i+1:]
+	//gobra:end-old-code 04ab994e84db0990f91b85600e4e43ef0bfd1fd0cabfef3b1c509860ace6cc65
+	// @ unfold acc(sl.Bytes(path, 0, len(path)), R41)
+	// @ SubSliceOverlaps(path, 0, i+1)
+	dir = path[:i+1]
+	// @ fold acc(sl.Bytes(dir, 0, len(dir)), R41)
+	// @ SubSliceOverlaps(path, i+1, len(path))
+	file = path[i+1:]
+	// @ fold acc(sl.Bytes(file, 0, len(file)), R41)
+	return dir, file
+	//gobra:endrewrite 04ab994e84db0990f91b85600e4e43ef0bfd1fd0cabfef3b1c509860ace6cc65
 }
 
 // Join joins any number of path elements into a single path,
@@ -159,47 +577,60 @@ func Split(path string) (dir, file string) {
 // The result is Cleaned. However, if the argument list is
 // empty or all its elements are empty, Join returns
 // an empty string.
-func Join(elem ...string) string {
+// @ trusted
+func Join(elem []string_byte) string_byte {
 	size := 0
 	for _, e := range elem {
 		size += len(e)
 	}
 	if size == 0 {
-		return ""
+		return string_byte{}
 	}
 	buf := make([]byte, 0, size+len(elem)-1)
 	for _, e := range elem {
-		if len(buf) > 0 || e != "" {
+		//gobra:rewrite 88352fa84dd71f512688eb2be16383939fc26545c129deb8462fd5178583bdff
+		//gobra:cont 		if len(buf) > 0 || e != "" {
+		//gobra:end-old-code 88352fa84dd71f512688eb2be16383939fc26545c129deb8462fd5178583bdff
+		if len(buf) > 0 || len(e) != 0 {
+			//gobra:endrewrite 88352fa84dd71f512688eb2be16383939fc26545c129deb8462fd5178583bdff
 			if len(buf) > 0 {
-				buf = append(buf, '/')
+				buf = append( /* @ R40 , @ */ buf, '/')
 			}
-			buf = append(buf, e...)
+			buf = append( /* @ R40, @ */ buf, e...)
 		}
 	}
-	return Clean(string(buf))
+	return Clean(string_byte(buf))
 }
 
 // Ext returns the file name extension used by path.
 // The extension is the suffix beginning at the final dot
 // in the final slash-separated element of path;
 // it is empty if there is no dot.
-func Ext(path string) string {
+// @ trusted
+func Ext(path string_byte) string_byte {
 	for i := len(path) - 1; i >= 0 && path[i] != '/'; i-- {
 		if path[i] == '.' {
 			return path[i:]
 		}
 	}
-	return ""
+	return string_byte{}
 }
 
 // Base returns the last element of path.
 // Trailing slashes are removed before extracting the last element.
 // If the path is empty, Base returns ".".
 // If the path consists entirely of slashes, Base returns "/".
-func Base(path string) string {
-	if path == "" {
-		return "."
+// @ trusted
+func Base(path string_byte) string_byte {
+	//gobra:rewrite 70493558394bddd26fc4913b3282a2fc8d74fce232cdd1932ae5fad203b0798b
+	//gobra:cont 	if path == "" {
+	//gobra:cont 		return "."
+	//gobra:cont 	}
+	//gobra:end-old-code 70493558394bddd26fc4913b3282a2fc8d74fce232cdd1932ae5fad203b0798b
+	if len(path) == 0 {
+		return string_byte{'.'}
 	}
+	//gobra:endrewrite 70493558394bddd26fc4913b3282a2fc8d74fce232cdd1932ae5fad203b0798b
 	// Strip trailing slashes.
 	for len(path) > 0 && path[len(path)-1] == '/' {
 		path = path[0 : len(path)-1]
@@ -209,14 +640,15 @@ func Base(path string) string {
 		path = path[i+1:]
 	}
 	// If empty now, it had only slashes.
-	if path == "" {
-		return "/"
+	if len(path) == 0 {
+		return string_byte{'/'}
 	}
 	return path
 }
 
 // IsAbs reports whether the path is absolute.
-func IsAbs(path string) bool {
+// @ trusted
+func IsAbs(path string_byte) bool {
 	return len(path) > 0 && path[0] == '/'
 }
 
@@ -227,7 +659,8 @@ func IsAbs(path string) bool {
 // If the path consists entirely of slashes followed by non-slash bytes, Dir
 // returns a single slash. In any other case, the returned path does not end in a
 // slash.
-func Dir(path string) string {
+// @ trusted
+func Dir(path string_byte) string_byte {
 	dir, _ := Split(path)
 	return Clean(dir)
 }

--- a/src/path/path_spec.gobra
+++ b/src/path/path_spec.gobra
@@ -1,0 +1,1111 @@
+package path
+
+//+gobra
+
+import (
+	bytes "bytes/spec"
+	sl "verification/utils/slices"
+	.  "verification/utils/definitions"
+)
+
+pred Lazybuf(b *lazybuf, p perm) {
+	0 < p &&
+	acc(b) &&
+	0 < len(b.s) &&
+	(b.buf != nil ==> InRangeInc(b.w, 0, len(b.buf))) &&
+	InRangeInc(b.w, 0, len(b.s)) &&
+	(b.buf == nil || len(b.buf) == len(b.s)) &&
+	acc(sl.Bytes(b.s, 0, len(b.s)), p) &&
+	sl.Bytes(b.buf, 0, len(b.buf))
+}
+
+ghost
+requires Lazybuf(b, R41)
+decreases
+pure func lazybufInvariant(b *lazybuf) (res bool) {
+	// return (getS(b)[:getW(b)] == getValue(b)) == bufIsEmpty(b) &&
+	// return true &&
+	// 	bufIsEmpty(b) == (unfolding Lazybuf(b, R41) in b.buf == nil)
+	return true
+}
+
+type Segment seq[byte]
+
+// type path adt {
+// 	Rooted { parts seq[segment] }
+// 	Relative { parts seq[segment] }
+// }
+
+type Path struct {
+	ghost parts  seq[Segment]
+	rooted bool
+}
+
+
+ghost
+requires len(p.parts) > 0
+decreases
+pure func (p Path) dirname() (res seq[Segment]) {
+	return p.parts[:len(p.parts)-1]
+}
+
+ghost
+requires len(p.parts) > 0
+decreases
+pure func (p Path) basename() (res Segment) {
+	return p.parts[len(p.parts)-1]
+}
+
+ghost
+decreases
+pure func newPath(rooted bool) (res Path) {
+	return Path{parts: seq[Segment]{}, rooted: rooted}
+}
+
+ghost
+decreases
+pure func pathAppend(p Path, s Segment) (res Path) {
+	return Path{
+		parts: p.parts ++ seq[Segment]{s},
+		rooted: p.rooted,
+	}
+}
+
+ghost
+requires Lazybuf(b, R41)
+ensures acc(b)
+ensures acc(sl.Bytes(b.s, 0, len(b.s)), R41)
+decreases _
+func lemmaFunnyUnfold(b *lazybuf) {
+	unfold Lazybuf(b, R41)
+}
+
+ghost
+requires acc(Lazybuf(b, R41), _)
+decreases
+pure func getW(b *lazybuf) (res int) {
+	return unfolding acc(Lazybuf(b, R41), _) in b.w
+}
+
+ghost
+requires acc(Lazybuf(b, R41), _)
+ensures len(res) == getW(b)
+decreases
+pure func getValue(b *lazybuf) (res seq[byte]) {
+	return unfolding acc(Lazybuf(b, R41), _) in b.buf == nil ?
+		bytes.View(b.s)[:b.w] :
+		bytes.View(b.buf)[:b.w]
+}
+
+ghost
+requires acc(Lazybuf(b, R41), _)
+ensures len(res) == len(getS(b))
+decreases
+pure func (b *lazybuf) valueUntrimmed() (res seq[byte]) {
+	return unfolding acc(Lazybuf(b, R41), _) in b.buf == nil ?
+		bytes.View(b.s) :
+		bytes.View(b.buf)
+}
+
+ghost
+decreases
+pure func isRooted(p seq[byte]) (res bool) {
+	return len(p) > 0 && p[0] == '/'
+}
+
+ghost
+decreases
+pure func pathContents(p seq[byte]) (res seq[byte]) {
+	return isRooted(p) ?
+		p[1:] :
+		p
+}
+
+ghost
+requires acc(Lazybuf(b, R41), _)
+decreases
+pure func (b *lazybuf) Path() (res Path) {
+	// return toPath( bytes.SpecSplit(pathContents(getValue(b)), seq[byte]{'/'} ), isRooted(getValue(b)))
+	// return toPath( bytes.SpecSplit(seq[byte]{}) , isRooted(getValue(b)))
+	return ToPath(getValue(b))
+}
+
+ghost
+ensures res.rooted == isRooted(path)
+decreases
+pure func ToPath(path seq[byte]) (res Path) {
+	return toPath( bytes.SpecSplit(pathContents(path), seq[byte]{'/'} ), isRooted(path))
+	// return toPath( bytes.SpecSplit(pathContents(path), seq[byte]{'/'} ), isRooted(path))
+}
+
+ghost
+ensures res.rooted == rooted
+ensures res.parts == flat
+decreases len(flat)
+pure func toPath(flat seq[seq[byte]], rooted bool) (res Path) {
+	return len(flat) == 0 ?
+		newPath(rooted) :
+		pathAppend( toPath(flat[:len(flat)-1], rooted), flat[len(flat)-1] )
+}
+
+
+ghost
+requires acc(Lazybuf(b, R41), _)
+requires InRange(i, 0, len(getS(b)))
+decreases
+pure func (b *lazybuf) specIndex(i int) (res byte) {
+	return b.valueUntrimmed()[i]
+}
+
+ghost
+requires acc(Lazybuf(b, R41), _)
+decreases
+pure func getS(b *lazybuf) (res seq[byte]) {
+	return unfolding acc(Lazybuf(b, R41), _) in
+		bytes.View(b.s)
+}
+
+// ghost
+// decreases
+// pure func (b *lazybuf)
+
+ghost
+requires acc(Lazybuf(b, R41), _)
+decreases
+pure func bufIsEmpty(b *lazybuf) (res bool) {
+	return unfolding acc(Lazybuf(b, R41), _) in
+		len(b.buf) == 0
+}
+
+ghost
+requires false
+requires 0 < p1
+requires 0 < p2
+requires p2 < p1
+requires Lazybuf(b, p1)
+ensures Lazybuf(b, p2)
+ensures Lazybuf(b, p2) --* Lazybuf(b, p1)
+decreases _
+func lemmaLazybufReduce(b *lazybuf, p1, p2 perm) {
+	unfold Lazybuf(b, p1)
+	assert acc(sl.Bytes(b.s, 0, len(b.s)), p1)
+	fold Lazybuf(b, p2)
+	assert acc(sl.Bytes(b.s, 0, len(b.s)), p1-p2)
+	package Lazybuf(b, p2) --* Lazybuf(b, p1) {
+		unfold Lazybuf(b, p2)
+		fold Lazybuf(b, p1)
+	}
+}
+
+ghost
+requires 0 < len(s)
+decreases
+pure func lastByte(s seq[byte]) (res byte) {
+	return s[len(s) - 1]
+}
+
+ghost
+requires rooted ==> 1 <= len(path)
+decreases
+pure func noTrailingSlash(path seq[byte], rooted bool) (res bool) {
+	return rooted ?
+		len(path) != 1 ==> lastByte(path) != '/' :
+		len(path) != 0 ==> lastByte(path) != '/'
+}
+
+ghost
+ensures res == forall i int :: { path[i] } InRange(i, 1, len(path)) ==> path[i] == '/' ==> path[i-1] != '/'
+decreases len(path)
+pure func noDoubleSlash(path seq[byte]) (res bool) {
+	return len(path) <= 1 ||
+	((path[len(path) - 1] == '/' ==> path[len(path) - 2] != '/') &&
+		noDoubleSlash(path[:len(path)-1]))
+}
+
+ghost
+decreases
+pure func dotdotInvariant(dotdot int, rooted bool, buf seq[byte]) (res bool) {
+	return InRangeInc(dotdot, rooted ? 1 : 0, len(buf)) &&
+	(dotdot == (rooted ? 1 : 0) || buf[dotdot-1] != '/')
+}
+
+ghost
+decreases
+pure func startIndex(rooted bool) (res int) {
+	return rooted ? 1 : 0
+}
+
+ghost
+requires InRangeInc(r, 0, len(path))
+decreases
+pure func haveReadEntireSegment(path seq[byte], r int) (res bool) {
+	return r == len(path) ||
+		r == 0 ||
+		path[r-1] == '/' ||
+		isCurrentDir(path, r)
+}
+
+ghost
+requires InRange(r, 1, len(path))
+decreases
+pure func isCurrentDir(path seq[byte], r int) (res bool) {
+	return path[r] == '/' &&
+		path[r-1] == '.' &&
+		(r == 1 || path[r-2] == '/')
+}
+
+ghost
+requires rooted ==> InRangeInc(r, 1, len(path))
+requires !rooted ==> InRangeInc(r, 0, len(path))
+decreases
+pure func noIncompleteRead(path seq[byte], r int, rooted bool) (res bool) {
+	return rooted ?
+		haveReadEntireSegment(path[1:], r-1) :
+		haveReadEntireSegment(path, r)
+}
+
+ghost
+requires noDoubleSlash(prev)
+requires InRange(w, 0, len(prev))
+requires rooted ==> 1 <= w
+requires prev[w] == '/'
+ensures noTrailingSlash(prev[:w], rooted)
+decreases
+func lemmaNoTrailingSlash(prev seq[byte], w int, rooted bool) {
+	if len(prev) <= 1 {
+		assert noTrailingSlash(prev[:w], rooted)
+		return
+	}
+}
+
+ghost
+requires a <= b && b <= c
+ensures a <= c
+decreases
+func lemmaLeqTransitive(a, b, c int) {
+	
+}
+
+ghost
+requires aLast != bLast
+ensures a ++ seq[byte]{aLast} != b ++ seq[byte]{bLast}
+decreases
+func lemmaSlicesIneqLastElem(a, b seq[byte], aLast, bLast byte) {
+	if a == b {
+		newa := a ++ seq[byte]{aLast}
+		newb := b ++ seq[byte]{bLast}
+		i := len(newa)-1
+		assert newa[i] != newb[i]
+		assert newa != newb
+	} else {
+		assert a ++ seq[byte]{aLast} != b ++ seq[byte]{bLast}
+	}
+}
+
+// technically this axiom is not needed. however,
+// I was encountering some issues with the permissions.
+// Since `string` is not a mutable type in the first place,
+// this axiom exists to focus on the more interesting parts
+// of the program
+ghost
+ensures acc(sl.Bytes(path, 0, len(path)), R40)
+trusted
+decreases _
+func axiomStringByteAcc(path string_byte)
+
+ghost
+requires InRangeInc(r, 0, len(p))
+decreases
+pure func readingIsAheadOfWriting(p seq[byte], w, r int, rooted bool) (res bool) {
+	return r == len(p)|| p[r] == '/' || (w != startIndex(rooted) ==> w < r)
+}
+
+ghost
+requires forall i int :: {&a[i]} 0 <= i && i < len(a) ==> acc(&a[i], _)
+requires forall i int :: {&b[i]} 0 <= i && i < len(b) ==> acc(&b[i], _)
+ensures res == (len(a) == len(b) && forall i int :: {&a[i]}{&b[i]} InRange(i, 0, len(a)) ==> &a[i] == &b[i] )
+decreases len(a) + len(b)
+pure func sameSlice(a, b []byte) (res bool) {
+	return (len(a) == 0 || len(b) == 0 ) ?
+		(len(a) == 0 && len(b) == 0) :
+		(&a[len(a)-1] == &b[len(b)-1] && sameSlice(a[:len(a)-1], b[:len(b)-1]))
+}
+
+ghost
+ensures len(res) == 2
+decreases
+pure func dotdot() (res Segment) {
+	return seq[byte]{'.', '.'}
+}
+
+ghost
+ensures len(res) == 1
+decreases
+pure func dot() (res Segment) {
+	return seq[byte]{'.'}
+}
+
+ghost
+ensures forall i int :: {res.parts[i]} InRange(i, 0, len(res.parts)) ==> len(res.parts[i]) != 0
+decreases
+pure func SpecClean(p Path) (res Path) {
+	return (!p.rooted && len(p.parts) == 0) ?
+		Path  { rooted: false, parts: seq[Segment]{dot()} } :
+		p.rooted ?
+			Path { rooted: true, parts: SpecCleanRooted(p.parts, seq[Segment]{}) } :
+			Path { rooted: false, parts: SpecCleanRelative(p.parts, seq[Segment]{}) }
+}
+
+var empty Segment = seq[byte]{}
+
+ghost
+requires forall i int :: {accum[i]} InRange(i, 0, len(accum)) ==> len(accum[i]) != 0
+ensures forall i int :: {res[i]} InRange(i, 0, len(res)) ==> len(res[i]) != 0
+decreases len(p)
+pure func SpecCleanRooted(p, accum seq[Segment]) (res seq[Segment]) {
+	return len(p) == 0 ?
+		accum :
+		(p[0] == dotdot() && len(accum) == 0) || p[0] == dot() || len(p[0]) == 0 ?
+			SpecCleanRooted(p[1:], accum) :
+			p[0] == dotdot() ?
+				SpecCleanRooted(p[1:], accum[:len(accum)-1]) :
+				SpecCleanRooted(p[1:], accum ++ seq[Segment]{ p[0] })
+}
+
+ghost
+requires forall i int :: {accum[i]} InRange(i, 0, len(accum)) ==> len(accum[i]) != 0
+ensures forall i int :: {res[i]} InRange(i, 0, len(res)) ==> len(res[i]) != 0
+decreases len(p)
+pure func SpecCleanRelative(p, accum seq[Segment]) (res seq[Segment]) {
+	return len(p) == 0 ?
+		accum :
+		(p[0] == dotdot()) && (len(accum) == 0 || accum[len(accum)-1] == dotdot()) ?
+			SpecCleanRelative(p[1:], accum ++ seq[Segment]{dotdot()}) :
+			p[0] == dotdot() ?
+				SpecCleanRelative(p[1:], accum ++ seq[Segment]{dotdot()}) :
+				(p[0] == dot() || len(p[0]) == 0) ?
+					SpecCleanRelative(p[1:], accum) :
+					SpecCleanRelative(p[1:], accum ++ seq[Segment]{p[0]})
+}
+
+ghost
+decreases
+pure func isCompleted(p seq[byte]) (res bool) {
+	return len(p) == 0 || p[len(p)-1] == '/'
+}
+
+ghost
+requires InRangeInc(r, 0, len(p))
+decreases
+pure func willBeCompleted(p seq[byte], r int) (res bool) {
+	return len(p) == r || p[r] == '/'
+}
+
+ghost
+requires rooted ==> 1 <= len(p)
+requires rooted ==> p[0] == '/'
+requires !rooted && 1 <= len(p) ==> p[0] != '/'
+requires noTrailingSlash(p, rooted)
+ensures len(ToPath(p).parts) == 0 || len(ToPath(p).basename()) != 0
+decreases
+func lemmaNoTrailingSlashPath(p seq[byte], rooted bool) {
+	switch {
+		case rooted && len(p) == 1:
+			assert len(ToPath(p).parts) == 0
+		case rooted && len(p) != 1:
+			assert lastByte(p) != '/'
+			lemmaToPathNonEmpty(p)
+			lemmaToPathHasTail(p)
+			assert len(ToPath(p).basename()) != 0
+			
+		case !rooted && len(p) == 0:
+			assert len(ToPath(p).parts) == 0
+		case !rooted && len(p) != 0:
+			assert lastByte(p) != '/'
+			lemmaToPathNonEmpty(p)
+			lemmaToPathHasTail(p)
+			assert len(ToPath(p).basename()) != 0
+
+		default:
+			assert false
+	}
+}
+
+
+// ToPath lemmas:
+
+ghost
+requires len(p) == 0
+ensures !ToPath(p).rooted
+ensures len(ToPath(p).parts) == 0
+decreases
+func lemmaToPathEmpty(p seq[byte]) {
+
+	assert toPath(seq[seq[byte]]{}, false) == Path{parts:seq[Segment]{},rooted:false,}
+	assert isRooted(seq[byte]{}) == false
+	assert bytes.SpecSplitInner(seq[byte]{}, seq[byte]{'/'}, seq[byte]{}) == seq[seq[byte]]{}
+	assert bytes.SpecSplit(seq[byte]{}, seq[byte]{'/'}) == seq[seq[byte]]{}
+	assert isRooted(seq[byte]{}) == false
+	assert pathContents(seq[byte]{}) == seq[byte]{}
+	assert ToPath(seq[byte]{}) == Path{rooted:false,parts:seq[Segment]{},}
+
+}
+
+
+ghost
+requires 0 < len(p)
+requires p[0] == '/' ==> 1 < len(p)
+ensures len(ToPath(p).parts) != 0
+decreases
+func lemmaToPathNonEmpty(p seq[byte]) {
+	sep := seq[byte]{'/'}
+	if p[0] == '/' {
+		assert ToPath(p) == toPath(bytes.SpecSplit(pathContents(p), sep), isRooted(p))
+		assert pathContents(p) == p[1:]
+		assert isRooted(p)
+
+		ghost split := bytes.SpecSplit(p[1:], sep)
+		assert len(p[1:]) != 0
+		bytes.LemmaSpecSplitNonEmpty(p[1:], sep)
+		assert 0 < len(split)
+	} else {
+		assert ToPath(p) == toPath(bytes.SpecSplit(pathContents(p), sep), isRooted(p))
+		assert pathContents(p) == p
+		assert !isRooted(p)
+
+		ghost split := bytes.SpecSplit(p, sep)
+		bytes.LemmaSpecSplitNonEmpty(p, sep)
+	}
+}
+
+ghost
+requires 0 < len(p)
+requires lastByte(p) != '/'
+ensures len(ToPath(p).parts) > 0
+decreases
+func lemmaToPathWithoutTrailingSlash(p seq[byte]) {
+	assert p[0] == '/' ==> 1 < len(p)
+	lemmaToPathNonEmpty(p)
+}
+
+ghost
+requires 0 < len(s)
+requires add != '/'
+requires res1 == bytes.SpecSplit(s, seq[byte]{'/'})
+requires res2 == bytes.SpecSplit(s ++ seq[byte]{add}, seq[byte]{'/'})
+ensures len(res1) == len(res2)
+ensures 0 < len(res1)
+ensures res1[:len(res1)-1] == res2[:len(res2)-1]
+ensures res1[len(res1)-1] ++ seq[byte]{add} == res2[len(res2)-1]
+decreases
+func lemmaSplitAddNonSep(s seq[byte], add byte, res1, res2 seq[seq[byte]]) {
+	lemmaSplitInnerAddNonSep(s, seq[byte]{}, add, res1, res2)
+}
+
+ghost
+requires 0 < len(s)
+requires add != '/'
+requires res1 == bytes.SpecSplitInner(s, seq[byte]{'/'}, ac)
+requires res2 == bytes.SpecSplitInner(s ++ seq[byte]{add}, seq[byte]{'/'}, ac)
+ensures len(res1) == len(res2)
+ensures 0 < len(res1)
+ensures res1[:len(res1)-1] == res2[:len(res2)-1]
+ensures res1[len(res1)-1] ++ seq[byte]{add} == res2[len(res2)-1]
+decreases len(s)
+func lemmaSplitInnerAddNonSep(s, ac seq[byte], add byte, res1, res2 seq[seq[byte]]) {
+	sep := seq[byte]{'/'}
+	added := s ++ seq[byte]{add}
+	switch {
+	case s == sep:
+		assert added == seq[byte]{'/', add}
+		assert res1 == seq[seq[byte]]{ ac, seq[byte]{} }
+
+		assert bytes.SpecSplitInner(added, sep, ac) == seq[seq[byte]]{ac} ++ bytes.SpecSplitInner(added[1:], sep, seq[byte]{} )
+		assert added[1:] == seq[byte]{add}
+		assert bytes.SpecSplitInner(added[1:], sep, seq[byte]{}) == bytes.SpecSplitInner(seq[byte]{add}, sep, seq[byte]{})
+		assert seq[byte]{add} != sep
+		assert seq[byte]{add}[:1] != sep
+		assert seq[byte]{add}[1:] == seq[byte]{}
+		assert bytes.SpecSplitInner(seq[byte]{add}, sep, seq[byte]{}) == bytes.SpecSplitInner(seq[byte]{}, sep, seq[byte]{add})
+		assert bytes.SpecSplitInner(seq[byte]{}, sep, seq[byte]{add}) == seq[seq[byte]]{ seq[byte]{add} }
+
+		assert res2 == seq[seq[byte]]{ac, seq[byte]{add}}
+
+		assert res1[len(res1)-1] ++ seq[byte]{add} == res2[len(res2)-1]
+		assert res1[:len(res1)-1] == res2[:len(res2)-1]
+	case s[:len(sep)] == sep:
+
+
+		assert res1 == seq[seq[byte]]{ac} ++ bytes.SpecSplitInner(s[len(sep):], sep, seq[byte]{})
+		assert res2 == seq[seq[byte]]{ac} ++ bytes.SpecSplitInner(added[len(sep):], sep, seq[byte]{})
+		assert s[len(sep):] ++ seq[byte]{add} == added[len(sep):]
+		r1 := bytes.SpecSplitInner(s[len(sep):], sep, seq[byte]{})
+		r2 := bytes.SpecSplitInner(added[len(sep):], sep, seq[byte]{})
+
+		lemmaSplitInnerAddNonSep(s[len(sep):], seq[byte]{}, add, r1, r2)
+
+
+		assert res1[len(res1)-1] ++ seq[byte]{add} == res2[len(res2)-1]
+		assert res1[:len(res1)-1] == res2[:len(res2)-1]
+	case len(s) == 1:
+		assert res1 == bytes.SpecSplitInner(s[1:], sep, ac ++ seq[byte]{s[0]})
+		assert res2 == bytes.SpecSplitInner(added[1:], sep, ac ++ seq[byte]{added[0]})
+
+		assert s[1:] == seq[byte]{}
+		assert bytes.SpecSplitInner(seq[byte]{}, sep, ac ++ seq[byte]{s[0]}) == seq[seq[byte]]{ ac ++ seq[byte]{s[0]} }
+		assert res1 == seq[seq[byte]]{ ac ++ seq[byte]{s[0]} }
+
+		assert added[1:] == seq[byte]{add}
+		assert bytes.SpecSplitInner(seq[byte]{add}, sep, ac ++ seq[byte]{added[0]}) == bytes.SpecSplitInner(seq[byte]{add}[1:], sep, ac ++ seq[byte]{added[0]} ++ seq[byte]{added[1]} )
+
+
+		assert res1[len(res1)-1] ++ seq[byte]{add} == res2[len(res2)-1]
+		assert res1[:len(res1)-1] == res2[:len(res2)-1]
+	default:
+
+		assert len(s) >= 2
+
+		assert res1 == bytes.SpecSplitInner(s[1:], sep, ac ++ seq[byte]{s[0]})
+		assert res2 == bytes.SpecSplitInner(added[1:], sep, ac ++ seq[byte]{added[0]})
+		
+		r1 := bytes.SpecSplitInner(s[1:], sep, ac ++ seq[byte]{s[0]})
+		r2 := bytes.SpecSplitInner(added[1:], sep, ac ++ seq[byte]{added[0]}) 
+
+		assert s[1:] ++ seq[byte]{add} == added[1:]
+
+		lemmaSplitInnerAddNonSep(s[1:], ac ++ seq[byte]{added[0]}, add, res1, res2)
+		assert res1[len(res1)-1] ++ seq[byte]{add} == res2[len(res2)-1]
+		assert res1[:len(res1)-1] == res2[:len(res2)-1]
+	}
+}
+
+// ghost
+// requires res == bytes.SpecSplitInner(s, seq[byte]{'/'}, ac)
+// requires len(ac) > 0
+// ensures 0 < len(res[len(res)-1])
+// decreases
+// func lemmaSplitInnerNoTrailingSlash(p, ac seq[byte], res seq[seq[byte]]) {
+// }
+
+
+// ghost
+// requires 0 < len(p)
+// requires p[len(p)-1] != '/'
+// ensures 0 < len(bytes.SpecSplit(p, seq[byte]{'/'}))
+// ensures 0 < len(bytes.SpecSplit(p, seq[byte]{'/'})[len(bytes.SpecSplit(p, seq[byte]{'/'}))-1])
+// decreases len(p)
+// func lemmaSplitNoTrailingSlash(p seq[byte]) {
+// 	bytes.LemmaSpecSplitNonEmpty(p, seq[byte]{'/'})
+// 	res := bytes.SpecSplit(p, seq[byte]{'/'})
+// 	sep := seq[byte]{'/'}
+//
+// 	assert p != sep
+// 	if p[:1] == sep {
+// 		assert len(p[1:]) != 0
+// 		res2 := bytes.SpecSplitInner(p[1:], sep, seq[byte]{})
+// 		assert res[1:] == res2
+// 		lemmaSplitNoTrailingSlash(p[1:])
+// 		assert res[len(res)-1] == res2[len(res2)-1]
+// 		assert 0 < len(res[len(res)-1])
+// 	} else {
+// 		if len(p[1:]) == 0 {
+// 			assert res == bytes.SpecSplitInner(p[1:], sep, seq[byte]{p[0]})
+// 			res2 := bytes.SpecSplitInner(p[1:], sep, seq[byte]{p[0]})
+// 			assert res2[len(res2)-1] == seq[byte]{p[0]}
+//
+// 			assert 0 < len(res[len(res)-1])
+// 		} else {
+// 			lemmaSplitNoTrailingSlash(p[1:])
+// 			assert res == bytes.SpecSplitInner(p[1:], sep, seq[byte]{p[0]})
+//
+//
+// 			assert 0 < len(res[len(res)-1])
+// 		}
+// 		assert 0 < len(res[len(res)-1])
+// 	}
+//
+// 	assert 0 < len(res[len(res)-1])
+// }
+
+ghost
+requires 0 < len(p)
+requires lastByte(p) != '/'
+ensures len(ToPath(p).parts) > 0
+ensures len(ToPath(p).basename()) != 0
+decreases
+func lemmaToPathHasTail(p seq[byte]) {
+	// lemmaToPathWithoutTrailingSlash(p)
+	// lemmaSplitNoTrailingSlash(p)
+
+
+	add := p[len(p)-1]
+	s := p[:len(p)-1]
+	sep := seq[byte]{'/'}
+
+	if len(p) == 1 {
+		assert pathContents(p) == p
+		assert isRooted(p) == false
+		assert bytes.SpecSplit(p, sep) == bytes.SpecSplitInner(p, sep, seq[byte]{})
+		assert p != sep
+		assert p[:1] != sep
+		assert bytes.SpecSplitInner(p, sep, seq[byte]{}) == bytes.SpecSplitInner(p[1:], sep, seq[byte]{ p[0] })
+		assert p[1:] == seq[byte]{}
+		assert bytes.SpecSplitInner(seq[byte]{}, sep, seq[byte]{ p[0] }) == seq[seq[byte]]{ seq[byte]{ p[0] } }
+		assert seq[byte]{ p[0] } == p
+		assert bytes.SpecSplit(p, sep) == seq[seq[byte]]{ p }
+		
+	} else {
+		res1 := bytes.SpecSplit(s, seq[byte]{'/'})
+		assert p == s ++ seq[byte]{add}
+		res2 := bytes.SpecSplit(p, seq[byte]{'/'})
+		lemmaSplitAddNonSep(s, add, res1, res2)
+	}
+}
+
+
+
+ghost
+requires 0 < len(flat1)
+requires 0 < len(flat2)
+requires flat1[len(flat1)-1] ++ seq[byte]{add} == flat2[len(flat2)-1]
+requires flat1[:len(flat1)-1] == flat2[:len(flat2)-1]
+ensures toPath(flat1, rooted).dirname() == toPath(flat2, rooted).dirname()
+ensures toPath(flat1, rooted).basename() ++ seq[byte]{add} == toPath(flat2, rooted).basename()
+decreases
+func lemma_toPathAddNormalChar(flat1, flat2 seq[seq[byte]], add byte, rooted bool) {
+}
+
+ghost
+requires a === b
+requires 0 < len(a.parts)
+requires 0 < len(b.parts)
+ensures a.dirname() == b.dirname()
+decreases
+func lemmaDirname(a, b Path) {
+	assert a.dirname() == a.parts[:len(a.parts)-1]
+	assert b.dirname() == b.parts[:len(b.parts)-1]
+	assert a.parts === b.parts
+}
+
+ghost
+requires ch != '/'
+requires 0 < len(p)
+requires p[0] == '/' ==> 1 < len(p)
+ensures 0 < len(ToPath(p).parts)
+ensures 0 < len(ToPath(p ++ seq[byte]{ch}).parts)
+ensures ToPath(p).dirname() == ToPath(p ++ seq[byte]{ch}).dirname()
+ensures ToPath(p).basename() ++ seq[byte]{ch} == ToPath(p ++ seq[byte]{ch}).basename()
+decreases
+func lemmaToPathPoppingNormalChar(p seq[byte], ch byte) {
+
+	with_ch := p ++ seq[byte]{ch}
+	lemmaToPathNonEmpty(p)
+	lemmaToPathNonEmpty(with_ch)
+	sep := seq[byte]{'/'}
+	lemmaSplitAddNonSep(p, ch, bytes.SpecSplit(p, sep), bytes.SpecSplit(with_ch, sep) )
+
+	if p[0] == '/' {
+		assert ToPath(p) == toPath( bytes.SpecSplit(p[1:], sep), true )
+		flat1 := bytes.SpecSplit(p[1:], sep)
+		flat2 := bytes.SpecSplit(p[1:] ++ seq[byte]{ch}, sep)
+		assert ToPath(p) == toPath( flat1, true )
+		assert ToPath(p) === toPath( flat1, true )
+		assert ToPath(with_ch) === toPath( bytes.SpecSplit (with_ch[1:], sep), true )
+		assert with_ch[1:] === p[1:] ++ seq[byte]{ch}
+		assert ToPath(with_ch) === toPath( flat2, true )
+		p1 := toPath( flat1, true )
+		p2 := toPath( flat2, true )
+		bytes.LemmaSpecSplitNonEmpty(p[1:], sep)
+		bytes.LemmaSpecSplitNonEmpty(p[1:] ++ seq[byte]{ch}, sep)
+		assert 0 < len(flat1)
+		assert 0 < len(flat2)
+		lemmaSplitAddNonSep(p[1:], ch, flat1, flat2 )
+		lemma_toPathAddNormalChar( flat1, flat2, ch, true )	
+		assert toPath(flat1, true).dirname() == toPath(flat2, true).dirname()
+		assert ToPath(p) == toPath( flat1, true )
+		assert ToPath(with_ch) === toPath( flat2, true )
+		assert toPath(flat1, true).dirname() == ToPath(p).dirname()
+		lemmaDirname(toPath(flat2, true), ToPath(with_ch))
+		assert toPath(flat2, true).dirname() == ToPath(with_ch).dirname()
+		assert ToPath(p).dirname() == ToPath(with_ch).dirname()
+
+		assert ToPath(p).dirname() == ToPath(p ++ seq[byte]{ch}).dirname()
+	} else {
+		assert ToPath(p) == toPath(bytes.SpecSplit(p, sep), false )
+		flat := bytes.SpecSplit(p, sep)
+		flat2 := bytes.SpecSplit(p ++ seq[byte]{ch}, sep)
+		bytes.LemmaSpecSplitNonEmpty(p, sep)
+		bytes.LemmaSpecSplitNonEmpty(p ++ seq[byte]{ch}, sep)
+		assert 0 < len(flat)
+		assert 0 < len(flat2)
+		lemmaSplitAddNonSep(p, ch, flat, flat2 )
+		lemma_toPathAddNormalChar(flat, flat2, ch, false)	
+
+		assert ToPath(p).dirname() == ToPath(p ++ seq[byte]{ch}).dirname()
+	}
+
+}
+
+
+
+ghost
+requires p == seq[byte]{'.'}
+ensures !ToPath(p).rooted
+ensures ToPath(p).parts == seq[Segment]{ dot() }
+decreases
+func lemmaToPathDot(p seq[byte]) {
+
+	sep := seq[byte]{'/'}
+
+	assert pathAppend(Path{rooted:false,parts:seq[Segment]{},}, p) == Path{rooted:false,parts:seq[Segment]{p},}
+	assert newPath(false) == Path{rooted:false,parts:seq[Segment]{},}
+	assert toPath(seq[seq[byte]]{}, false) == Path{parts:seq[Segment]{},rooted:false,}
+	assert toPath(seq[seq[byte]]{p}, false) == Path{rooted:false,parts:seq[Segment]{p},}
+	assert isRooted(p) == false
+	assert bytes.SpecSplitInner(seq[byte]{}, sep, p) == seq[seq[byte]]{p}
+	assert p[1:] == seq[byte]{}
+	assert bytes.SpecSplitInner(p, sep, seq[byte]{}) == bytes.SpecSplitInner(seq[byte]{}, sep, p)
+	assert bytes.SpecSplitInner(p, sep, seq[byte]{}) == seq[seq[byte]]{p}
+	assert bytes.SpecSplit(p, sep) == seq[seq[byte]]{p}
+	assert isRooted(p) == false
+	assert pathContents(p) == p
+	assert ToPath(p) == Path{parts:seq[Segment]{p},rooted:false,}
+
+}
+
+ghost
+requires 0 < len(s)
+requires res1 == bytes.SpecSplitInner(s, seq[byte]{'/'}, ac)
+requires res2 == bytes.SpecSplitInner(s ++ seq[byte]{'/'}, seq[byte]{'/'}, ac)
+ensures len(res1)+1 == len(res2)
+ensures 0 < len(res1)
+ensures res1 == res2[:len(res2)-1]
+ensures res2[len(res2)-1] == seq[byte]{}
+decreases len(s)
+func lemmaSplitInnerAddSep(s, ac seq[byte], res1, res2 seq[seq[byte]]) {
+	sep := seq[byte]{'/'}
+	s2 := s ++ seq[byte]{'/'}
+
+	switch {
+	case sep == s:
+		assert res1 == seq[seq[byte]]{ ac, seq[byte]{} }
+		assert res2 == seq[seq[byte]]{ ac } ++ bytes.SpecSplitInner(s2[len(sep):], sep, seq[byte]{})
+		assert s2[len(sep):] == sep
+		assert bytes.SpecSplitInner(sep, sep, seq[byte]{}) == seq[seq[byte]]{ seq[byte]{}, seq[byte]{} }
+		assert res2 == seq[seq[byte]]{ ac, seq[byte]{}, seq[byte]{} }
+	case s[:len(sep)] == sep:
+		r1 := bytes.SpecSplitInner(s[len(sep):], sep, seq[byte]{})
+		r2 := bytes.SpecSplitInner(s2[len(sep):], sep, seq[byte]{})
+
+		assert res1 == seq[seq[byte]]{ac} ++ r1
+		assert res2 == seq[seq[byte]]{ac} ++ r2
+
+		assert s2[len(sep):] == s[len(sep):] ++ seq[byte]{'/'}
+		lemmaSplitInnerAddSep(s[1:], seq[byte]{}, r1, r2)
+
+		assert len(res1)+1 == len(res2)
+	case len(s) == 1:
+		ch := s[0]
+		assert s[1:] == seq[byte]{}
+		assert s2[1:] == seq[byte]{'/'}
+		assert res1 == bytes.SpecSplitInner(s[1:], sep, ac ++ seq[byte]{s[0]})
+		assert res1 == seq[seq[byte]]{ ac ++ seq[byte]{s[0]} }
+
+
+		assert res2 == bytes.SpecSplitInner(s2[1:], sep, ac ++ seq[byte]{s[0]})
+		assert res2 == seq[seq[byte]]{ ac ++ seq[byte]{s[0]}, seq[byte]{} }
+
+
+	default:
+		r1 := bytes.SpecSplitInner(s[1:], sep, ac ++ seq[byte]{s[0]} )
+		r2 := bytes.SpecSplitInner(s2[1:], sep, ac ++ seq[byte]{s[0]} )
+		assert s2[1:] == s[1:] ++ seq[byte]{'/'}
+
+		assert res1 == r1
+		assert res2 == r2
+
+		lemmaSplitInnerAddSep(s[1:], ac ++ seq[byte]{s[0]}, r1, r2)
+		assert len(res1)+1 == len(res2)
+	}
+}
+
+// TODO
+ghost
+requires a == b
+ensures a === b
+trusted
+decreases
+func axiomEqualGhostEqualPath(a, b Path)
+
+ghost
+ensures toPath(p, rooted).parts == p
+decreases len(p)
+func lemma_toPathSplit(p seq[seq[byte]], rooted bool) {
+}
+
+ghost
+ensures toPath(a, rooted).parts ++ b == toPath(a ++ b, rooted).parts
+decreases
+func lemma_toPathPrefix(a, b seq[Segment], rooted bool) {
+	
+}
+
+
+ghost
+requires 0 < len(p)
+requires prev === ToPath(p)
+ensures ToPath(p ++ seq[byte]{ '/' }).rooted == prev.rooted
+ensures len(ToPath(p).parts) == 0 ==> ToPath(p ++ seq[byte]{ '/' }).parts == seq[Segment]{ seq[byte]{}, seq[byte]{} }
+ensures len(ToPath(p).parts) != 0 ==> ToPath(p ++ seq[byte]{ '/' }).parts == prev.parts ++ seq[Segment]{ seq[byte]{} }
+decreases
+func lemmaToPathAppendingSlash(prev Path, p seq[byte]) {
+	sep := seq[byte]{'/'}
+
+	r1 := bytes.SpecSplitInner(p, sep, seq[byte]{})
+	r2 := bytes.SpecSplitInner(p ++ sep, sep, seq[byte]{})
+	lemmaSplitInnerAddSep(p, seq[byte]{}, r1, r2)
+
+
+
+	empty := seq[byte]{}
+
+	switch {
+	case p == seq[byte]{}:
+		assert len(ToPath(p).parts) == 0
+		assert !isRooted(p)
+
+		assert ToPath(p ++ seq[byte]{ '/' }).parts == seq[Segment]{ empty, empty }
+		assert ToPath(p ++ seq[byte]{ '/' }).rooted == prev.rooted
+		assert len(ToPath(p).parts) == 0 ==> ToPath(p ++ seq[byte]{ '/' }).parts == seq[Segment]{ empty, empty }
+	case p == seq[byte]{'/'}:
+		assert len(ToPath(p).parts) == 0
+		assert isRooted(p)
+
+		assert ToPath(p ++ seq[byte]{ '/' }).rooted
+
+		assert pathContents(p ++ sep) == sep
+		assert bytes.SpecSplit(sep, sep) == bytes.SpecSplitInner(sep, sep, seq[byte]{})
+		assert bytes.SpecSplitInner(sep, sep, seq[byte]{}) == seq[seq[byte]]{ seq[byte]{}, seq[byte]{} }
+
+		flat := seq[seq[byte]]{ empty, empty }
+		assert ToPath(p ++ sep) == toPath( flat, true )
+		assert toPath(flat[:2], true) == newPath(true)
+		assert toPath(flat[:1], true) == pathAppend(newPath(true), empty)
+		assert toPath(flat, true) == pathAppend(pathAppend(newPath(true), empty), empty)
+
+		assert ToPath(p ++ seq[byte]{ '/' }).parts == seq[Segment]{ empty, empty }
+		assert prev.rooted
+		assert len(ToPath(p).parts) == 0 ==> ToPath(p ++ seq[byte]{ '/' }).parts == seq[Segment]{ empty, empty }
+	case p[0] == '/':
+		assert pathContents(p) == p[1:]
+		assert isRooted(p)
+		lemmaToPathNonEmpty(p)
+
+		assert len(ToPath(p).parts) != 0
+		assert ToPath(p ++ seq[byte]{ '/' }).rooted == prev.rooted
+
+		beforeSplit := bytes.SpecSplitInner( p[1:], sep, seq[byte]{} )
+		afterSplit := bytes.SpecSplitInner( p[1:] ++ sep, sep, seq[byte]{} )
+		assert ToPath(p) == toPath( beforeSplit, true )
+		assert ToPath(p) === toPath( beforeSplit, true )
+
+		assert ToPath(p ++ seq[byte]{'/'}) == toPath( bytes.SpecSplit(p[1:] ++ seq[byte]{'/'}, seq[byte]{'/'} ), true)
+		assert afterSplit == bytes.SpecSplit(p[1:] ++ seq[byte]{'/'}, seq[byte]{'/'} )
+		assert afterSplit === bytes.SpecSplit(p[1:] ++ seq[byte]{'/'}, seq[byte]{'/'} )
+		assert ToPath(p ++ seq[byte]{'/'}) == toPath( afterSplit, true)
+
+
+		r1 := bytes.SpecSplitInner(p[1:], seq[byte]{'/'}, seq[byte]{})
+		r2 := bytes.SpecSplitInner(p[1:] ++ seq[byte]{'/'}, seq[byte]{'/'}, seq[byte]{})
+
+		lemmaSplitInnerAddSep( p[1:], seq[byte]{}, r1, r2 )
+		assert afterSplit == beforeSplit ++ seq[seq[byte]]{ seq[byte]{} }
+		assert toPath(beforeSplit, true).parts == prev.parts
+
+		lemma_toPathPrefix(beforeSplit, seq[Segment]{ seq[byte]{} }, true)
+		assert toPath(beforeSplit, true).parts ++ seq[Segment]{ seq[byte]{} } == toPath(afterSplit, true).parts
+		assert ToPath(p ++ seq[byte]{ '/' }) == toPath(afterSplit, true)
+		assert prev == toPath(beforeSplit, true)
+		assert afterSplit == beforeSplit ++ seq[Segment]{ seq[byte]{} }
+		lemma_toPathSplit(afterSplit, true)
+		assert ToPath(p ++ seq[byte]{'/'}) == toPath(afterSplit, true)
+		axiomEqualGhostEqualPath(ToPath(p ++ seq[byte]{'/'}), toPath(afterSplit, true))
+		assert ToPath(p) === toPath(beforeSplit, true)
+		assert ToPath(p ++ seq[byte]{ '/' }).parts == prev.parts ++ seq[Segment]{ seq[byte]{} }
+	default:
+		assert pathContents(p) == p
+		assert !isRooted(p)
+
+		assert len(ToPath(p).parts) != 0
+		assert ToPath(p ++ seq[byte]{ '/' }).rooted == prev.rooted
+		assert len(ToPath(p).parts) == 0 ==> ToPath(p ++ seq[byte]{ '/' }).parts == seq[Segment]{ empty, empty }
+		assert ToPath(p ++ seq[byte]{ '/' }).parts == prev.parts ++ seq[Segment]{ seq[byte]{} }
+	}
+	assert len(ToPath(p).parts) == 0 ==> ToPath(p ++ seq[byte]{ '/' }).parts == seq[Segment]{ empty, empty }
+}
+
+// ghost
+// ensures bytes.SpecSplitInner(s1 ++ seq[byte]{'/'} ++ s2, seq[byte]{'/'}, ac) ==
+// 		bytes.SpecSplitInner(s1, seq[byte]{'/'}, ac) ++ bytes.SpecSplitInner(s2, seq[byte]{'/'}, seq[byte]{})
+// decreases len(s1)
+// func lemmaSpecSplitInnerAppend(s1, s2, ac seq[byte]) {
+// 	sep := seq[byte]{'/'}
+// 	split1 := bytes.SpecSplitInner(s1, seq[byte]{'/'}, ac)
+// 	split2 := bytes.SpecSplitInner(s2, seq[byte]{'/'}, seq[byte]{})
+// 	splitFull := bytes.SpecSplitInner(s1 ++ seq[byte]{'/'} ++ s2, seq[byte]{'/'}, ac)
+// 	switch {
+// 	case len(s1) == 0 && len(ac) == 0:
+// 		assert split1 == seq[seq[byte]]{}
+// 	case len(s1) == 0:
+// 	case sep == s1:
+// 	case s1[:len(sep)] == sep:
+// 	default:
+// 	}
+// }
+
+ghost
+ensures bytes.SpecSplitInner(seq[byte]{'.', '.'}, seq[byte]{'/'}, seq[byte]{}) == seq[seq[byte]]{ seq[byte]{'.', '.'} }
+decreases
+func lemmaSpecSplitInnerDotdot() {
+
+	res := seq[seq[byte]]{ seq[byte]{'.','.'} }
+	sep := seq[byte]{'/'}
+	
+	assert bytes.SpecSplitInner(seq[byte]{}, sep, seq[byte]{'.', '.'}) == res
+	assert seq[byte]{'.'}[1:] == seq[byte]{}
+	assert seq[byte]{'.'}[:1] == seq[byte]{'.'}
+	assert bytes.SpecSplitInner(seq[byte]{'.'}, sep, seq[byte]{'.'}) == res
+	assert seq[byte]{'.', '.'}[1:] == seq[byte]{'.'}
+	assert seq[byte]{'.', '.'}[:1] == seq[byte]{'.'}
+	assert bytes.SpecSplitInner(seq[byte]{'.', '.'}, sep, seq[byte]{}) == res
+}
+
+ghost
+requires a == b
+ensures c ++ a == c ++ b
+decreases
+func lemmaConcatEqualLeft(a, b, c seq[seq[byte]]) { }
+
+ghost
+ensures a ++ b ++ c == a ++ (b ++ c)
+decreases
+func lemmaConcatAssoc(a, b, c seq[seq[byte]]) { }
+
+ghost
+requires isCompleted(s)
+requires all == bytes.SpecSplitInner(s ++ seq[byte]{'.','.'}, seq[byte]{'/'}, ac)
+requires prefix == bytes.SpecSplitInner(s, seq[byte]{'/'}, ac)
+requires len(s) == 0 ==> len(ac) == 0
+ensures all == prefix[:len(prefix)-1] ++ seq[seq[byte]]{ seq[byte]{'.','.'} }
+decreases len(s)
+func lemmaSpecSplitInnerAppendDotdot(s, ac seq[byte], all, prefix seq[seq[byte]]) {
+	full := s ++ seq[byte]{'.', '.'}
+	tail := seq[seq[byte]]{ seq[byte]{'.','.'} }
+	sep := seq[byte]{'/'}
+
+	switch {
+	case len(s) == 0:
+		assert prefix == seq[seq[byte]]{}
+
+		lemmaSpecSplitInnerDotdot()
+
+		assert all == prefix[:len(prefix)-1] ++ tail
+	case sep == s:
+		assert prefix == seq[seq[byte]]{ ac, seq[byte]{} }
+		assert all == seq[seq[byte]]{ ac } ++ bytes.SpecSplitInner(full[len(sep):], sep, seq[byte]{})
+		assert full[len(sep):] == seq[byte]{'.','.'}
+		lemmaSpecSplitInnerDotdot()
+
+		assert all == prefix[:len(prefix)-1] ++ tail
+	case s[:len(sep)] == sep:
+		prefixp := bytes.SpecSplitInner(s[len(sep):], sep, seq[byte]{})
+		bytes.LemmaSpecSplitNonEmpty(s[1:], sep)
+		assert len(prefixp) != 0
+
+		allp := bytes.SpecSplitInner(full[len(sep):], sep, seq[byte]{})
+		
+		assert prefix == seq[seq[byte]]{ac} ++ prefixp
+		assert all == seq[seq[byte]]{ac} ++ allp
+
+		first := seq[seq[byte]]{ac}
+
+		assert full[1:] == s[1:] ++ seq[byte]{'.', '.'}
+		lemmaSpecSplitInnerAppendDotdot(s[1:], seq[byte]{}, allp, prefixp)
+		lemmaConcatEqualLeft(allp, prefixp[:len(prefixp)-1] ++ tail, first)
+		assert first ++ allp == first ++ (prefixp[:len(prefixp)-1] ++ tail)
+		assert first ++ allp == first ++ prefixp[:len(prefixp)-1] ++ tail
+		assert prefix[:len(prefix)-1] == first ++ prefixp[:len(prefixp)-1]
+		assert all == prefix[:len(prefix)-1] ++ tail
+	default:
+		acp := ac ++ seq[byte]{s[0]}
+		prefixp := bytes.SpecSplitInner(s[1:], sep, acp)
+		allp := bytes.SpecSplitInner(full[1:], sep, acp)
+		assert full[1:] == s[1:] ++ seq[byte]{'.', '.'}
+
+		lemmaSpecSplitInnerAppendDotdot(s[1:], acp, allp, prefixp)
+		
+		assert all == prefix[:len(prefix)-1] ++ tail
+	}
+
+	assert all == prefix[:len(prefix)-1] ++ tail
+	
+}
+
+ghost
+requires isCompleted(p)
+requires prev == ToPath(p)
+ensures ToPath(p ++ seq[byte]{ '.', '.' }).rooted == prev.rooted
+ensures ToPath(p ++ seq[byte]{ '.', '.' }).parts == prev.parts[:len(prev.parts)-1] ++ seq[Segment]{ dotdot() }
+decreases
+func lemmaToPathAppendingDotdot(prev Path, p seq[byte]) {
+	res := ToPath(p ++ seq[byte]{'.','.'})
+	sep := seq[byte]{'/'}
+	tail := seq[seq[byte]]{ seq[byte]{'.','.'} }
+	if len(p) == 0 || p[0] != '/' {
+		assert pathContents(p) == p
+		assert !isRooted(p)
+		rooted := false
+
+		split1 := bytes.SpecSplitInner(p, sep, seq[byte]{})
+		split2 := bytes.SpecSplitInner(p ++ seq[byte]{'.', '.'}, sep, seq[byte]{})
+		lemmaSpecSplitInnerAppendDotdot(p, seq[byte]{}, split2, split1)
+
+
+		assert res == toPath(bytes.SpecSplit(p, sep), rooted)
+		assert split1[:len(split1)-1] ++ tail == split2
+
+		assert prev == toPath(split1, rooted)
+		axiomEqualGhostEqualPath(prev, toPath(split1, rooted))
+		assert res  == toPath(split2, rooted)
+		axiomEqualGhostEqualPath(res, toPath(split2, rooted))
+		
+		lemma_toPathSplit(split1, rooted)
+		assert prev.parts == split1
+		assert res.parts == split2
+
+
+	} else {
+		assert pathContents(p) == p[1:]
+		assert isRooted(p)
+		rooted := true
+
+
+
+		split1 := bytes.SpecSplitInner(p[1:], sep, seq[byte]{})
+		split2 := bytes.SpecSplitInner(p[1:] ++ seq[byte]{'.', '.'}, sep, seq[byte]{})
+		lemmaSpecSplitInnerAppendDotdot(p[1:], seq[byte]{}, split2, split1)
+
+		assert res == toPath(bytes.SpecSplit(p, sep), rooted)
+		assert split1[:len(split1)-1] ++ tail == split2
+
+		assert prev == toPath(split1, rooted)
+		axiomEqualGhostEqualPath(prev, toPath(split1, rooted))
+		assert res  == toPath(split2, rooted)
+		axiomEqualGhostEqualPath(res, toPath(split2, rooted))
+		
+		lemma_toPathSplit(split1, rooted)
+		assert prev.parts == split1
+		assert res.parts == split2
+	}
+
+}

--- a/src/unicode/unicode.gobra
+++ b/src/unicode/unicode.gobra
@@ -1,0 +1,24 @@
+//+gobra
+
+package unicode
+
+
+func IsDigit(r rune) bool
+func IsLetter(r rune) bool
+func IsSpace(r rune) bool
+
+type d [4]rune // to make the CaseRanges text shorter
+type CaseRange struct {
+	Lo    uint32
+	Hi    uint32
+	Delta d
+}
+type SpecialCase []CaseRange
+
+func ToUpper(r rune) rune
+func ToLower(r rune) rune
+func ToTitle(r rune) rune
+func (special SpecialCase) ToUpper(r rune) rune
+func (special SpecialCase) ToTitle(r rune) rune
+func (special SpecialCase) ToLower(r rune) rune
+func SimpleFold(r rune) rune

--- a/src/unicode/unicode.gobra
+++ b/src/unicode/unicode.gobra
@@ -3,8 +3,16 @@
 package unicode
 
 
+trusted
+decreases
 func IsDigit(r rune) bool
+
+trusted
+decreases
 func IsLetter(r rune) bool
+
+trusted
+decreases
 func IsSpace(r rune) bool
 
 type d [4]rune // to make the CaseRanges text shorter
@@ -15,10 +23,30 @@ type CaseRange struct {
 }
 type SpecialCase []CaseRange
 
+trusted
+decreases
 func ToUpper(r rune) rune
+
+trusted
+decreases
 func ToLower(r rune) rune
+
+trusted
+decreases
 func ToTitle(r rune) rune
+
+trusted
+decreases
 func (special SpecialCase) ToUpper(r rune) rune
+
+trusted
+decreases
 func (special SpecialCase) ToTitle(r rune) rune
+
+trusted
+decreases
 func (special SpecialCase) ToLower(r rune) rune
+
+trusted
+decreases
 func SimpleFold(r rune) rune

--- a/src/unicode/utf8/utf8.gobra
+++ b/src/unicode/utf8/utf8.gobra
@@ -1,0 +1,53 @@
+package utf8
+//+gobra
+
+import (
+	. "verification/utils/definitions"
+	sl "verification/utils/slices"
+)
+
+// utf8.Codepoints(s) returns the sequence of (utf-8 encoded) codepoints in `s`
+ghost
+pure
+ensures 0 < len(s) ==> 0 < len(res)
+ensures 0 == len(s) ==> 0 == len(res)
+decreases
+func Codepoints(s []byte) (res seq[rune])
+
+
+const (
+	RuneError = '\uFFFD'
+	RuneSelf  = 0x80
+	MaxRune   = '\U0010FFFF'
+	UTFMax    = 4
+)
+
+// AppendRune appends the UTF-8 encoding of r to the end of p and
+// returns the extended buffer. If the rune is out of range,
+// it appends the encoding of [RuneError].
+func AppendRune(p []byte, r rune) []byte
+
+preserves acc(sl.Bytes(p, 0, len(p)), R40)
+ensures len(p) > 0 ==> 1 <= size && size <= len(p)
+ensures len(p) == 0 ==> size == 0
+ensures len(p) > 0 ==> Codepoints(p)[0] == r && Codepoints(p[size:]) == Codepoints(p)[1:]
+func DecodeRune(p []byte) (r rune, size int)
+
+preserves forall i int :: {&p[i]} 0 <= i && i < len(p) ==> acc(&p[i], R50)
+ensures 1 <= size && size <= len(p)
+func DecodeLastRune(p []byte) (r rune, size int)
+func RuneLen(r rune) int
+
+requires forall i int :: {&p[i]} 0 <= i && i < len(p) ==> acc(&p[i])
+ensures forall i int :: {&p[i]} 0 <= i && i < len(p) ==> acc(&p[i])
+ensures 0 <= n && n <= UTFMax
+func EncodeRune(p []byte, r rune) (n int)
+
+preserves acc(sl.Bytes(p, 0, len(p)), R50)
+ensures 0 <= res && res < len(p)
+ensures len(p) > 0 ==> res > 0
+ensures res == len(Codepoints(p))
+ensures len(indices) == res
+ensures forall i int :: {i in indices} i in indices ==> 0 <= i && i < len(p)
+func RuneCount(p []byte) (res int , ghost indices set[int])
+func ValidRune(r rune) (res bool)

--- a/src/unicode/utf8/utf8.gobra
+++ b/src/unicode/utf8/utf8.gobra
@@ -11,7 +11,7 @@ ghost
 pure
 ensures 0 < len(s) ==> 0 < len(res)
 ensures 0 == len(s) ==> 0 == len(res)
-decreases
+decreases _
 func Codepoints(s []byte) (res seq[rune])
 
 
@@ -31,16 +31,19 @@ preserves acc(sl.Bytes(p, 0, len(p)), R40)
 ensures len(p) > 0 ==> 1 <= size && size <= len(p)
 ensures len(p) == 0 ==> size == 0
 ensures len(p) > 0 ==> Codepoints(p)[0] == r && Codepoints(p[size:]) == Codepoints(p)[1:]
+decreases _
 func DecodeRune(p []byte) (r rune, size int)
 
 preserves forall i int :: {&p[i]} 0 <= i && i < len(p) ==> acc(&p[i], R50)
 ensures 1 <= size && size <= len(p)
+decreases _
 func DecodeLastRune(p []byte) (r rune, size int)
 func RuneLen(r rune) int
 
 requires forall i int :: {&p[i]} 0 <= i && i < len(p) ==> acc(&p[i])
 ensures forall i int :: {&p[i]} 0 <= i && i < len(p) ==> acc(&p[i])
 ensures 0 <= n && n <= UTFMax
+decreases _
 func EncodeRune(p []byte, r rune) (n int)
 
 preserves acc(sl.Bytes(p, 0, len(p)), R50)
@@ -49,5 +52,7 @@ ensures len(p) > 0 ==> res > 0
 ensures res == len(Codepoints(p))
 ensures len(indices) == res
 ensures forall i int :: {i in indices} i in indices ==> 0 <= i && i < len(p)
+decreases _
 func RuneCount(p []byte) (res int , ghost indices set[int])
+
 func ValidRune(r rune) (res bool)

--- a/src/unicode/utf8/utf8.gobra
+++ b/src/unicode/utf8/utf8.gobra
@@ -11,7 +11,8 @@ ghost
 pure
 ensures 0 < len(s) ==> 0 < len(res)
 ensures 0 == len(s) ==> 0 == len(res)
-decreases _
+trusted
+decreases
 func Codepoints(s []byte) (res seq[rune])
 
 
@@ -31,19 +32,24 @@ preserves acc(sl.Bytes(p, 0, len(p)), R40)
 ensures len(p) > 0 ==> 1 <= size && size <= len(p)
 ensures len(p) == 0 ==> size == 0
 ensures len(p) > 0 ==> Codepoints(p)[0] == r && Codepoints(p[size:]) == Codepoints(p)[1:]
-decreases _
+trusted
+decreases
 func DecodeRune(p []byte) (r rune, size int)
 
 preserves forall i int :: {&p[i]} 0 <= i && i < len(p) ==> acc(&p[i], R50)
 ensures 1 <= size && size <= len(p)
-decreases _
+trusted
+decreases
 func DecodeLastRune(p []byte) (r rune, size int)
+trusted
+decreases
 func RuneLen(r rune) int
 
 requires forall i int :: {&p[i]} 0 <= i && i < len(p) ==> acc(&p[i])
 ensures forall i int :: {&p[i]} 0 <= i && i < len(p) ==> acc(&p[i])
 ensures 0 <= n && n <= UTFMax
-decreases _
+trusted
+decreases
 func EncodeRune(p []byte, r rune) (n int)
 
 preserves acc(sl.Bytes(p, 0, len(p)), R50)
@@ -52,7 +58,10 @@ ensures len(p) > 0 ==> res > 0
 ensures res == len(Codepoints(p))
 ensures len(indices) == res
 ensures forall i int :: {i in indices} i in indices ==> 0 <= i && i < len(p)
-decreases _
+trusted
+decreases
 func RuneCount(p []byte) (res int , ghost indices set[int])
 
+trusted
+decreases
 func ValidRune(r rune) (res bool)

--- a/src/verification/utils/bitwise/bitwise.gobra
+++ b/src/verification/utils/bitwise/bitwise.gobra
@@ -1,0 +1,85 @@
+// Copyright 2022 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +gobra
+
+// This package contains some lemmas that are useful to deal with bitwise
+// operations in a scalable way. Look at the file './proofs.dfy' before
+// exteding this file.
+
+package bitwise
+
+ghost
+ensures 0 <= b && b < 256
+decreases
+func ByteValue(b byte)
+
+// TODO: prove this
+ghost
+pure
+ensures a == 0 || b == 0 ==> res == 0
+ensures a == 1 || b == 1 ==> res == 0 || res == 1
+ensures res == a & b
+decreases
+func BitAndBit(a, b int) (res int)
+
+ghost
+pure
+ensures 0 <= b & 0x3 && b & 0x3 <= 3
+ensures b == 0 ==> res == 0
+ensures b == 3 ==> res == 3
+ensures b == 4 ==> res == 0
+ensures res == b & 0x3
+decreases
+func BitAnd3(b int) (res int)
+
+ghost
+pure
+ensures 0 <= b & 0x7 && b & 0x7 <= 7
+ensures res == b & 0x7
+decreases
+func BitAnd7(b int) (res int)
+
+ghost
+ensures res == b >> 30
+ensures 0 <= res && res <= 3
+decreases
+pure func Shift30LessThan4(b uint32) (res uint32)
+
+ghost
+ensures res == b & 0x3F
+ensures 0 <= res && res < 64
+decreases
+pure func And3fAtMost64(b uint8) (res uint8)
+
+ghost
+ensures 0 | 1 == 1
+ensures 0 | 2 == 2
+ensures 1 | 2 == 3
+ensures 0 & 1 == 0
+ensures 0 & 2 == 0
+ensures 1 & 1 == 1
+ensures 1 & 2 == 0
+ensures 2 & 1 == 0
+ensures 2 & 2 == 2
+ensures 3 & 1 == 1
+ensures 3 & 2 == 2
+decreases
+pure func InfoFieldFirstByteSerializationLemmas() bool
+
+ensures csum > 0xffff ==>
+	let newCsum := (csum >> 16) + (csum & 0xffff) in
+	newCsum < csum
+decreases
+pure func FoldChecksumLemma(csum uint32) struct{}

--- a/src/verification/utils/bitwise/proofs.dfy
+++ b/src/verification/utils/bitwise/proofs.dfy
@@ -1,0 +1,172 @@
+// Goal of this file:
+//   Curently, Gobra's support for resoning about the values of bitwise operations is very limited.
+//   While this is not addressed, we rely on Dafny to prove that the lemmas hold, and we just provide
+//   an axiomatized version of the Lemma in Gobra. This is sub-optimal, but it is less than nothing.
+
+// How to extend:
+//   When a new lemma is needed, we should prove it in this file. If the lemma
+//   applies to Go's int type, we should introduce a lemma for when int has 32bit
+//   and for when it has 64bit.
+
+lemma ByteValue(b: bv8)
+	ensures 0 <= (b as int) && (b as int) < 256
+{}
+
+lemma BitAnd3_32bit(b: bv32)
+	ensures var res := b & 0x3;
+		0 <= res && res <= 3  &&
+		(b == 0 ==> res == 0) &&
+		(b == 3 ==> res == 3) &&
+		(b == 4 ==> res == 0)
+{}
+
+lemma BitAnd3_64bit(b: bv64)
+	ensures var res := b & 0x3;
+		0 <= res <= 3  &&
+		(b == 0 ==> res == 0) &&
+		(b == 3 ==> res == 3) &&
+		(b == 4 ==> res == 0)
+{}
+
+lemma BitAnd7_32bit(b: bv32)
+	ensures var res := b & 0x7;
+		0 <= res <= 7
+{}
+
+lemma BitAnd7_64bit(b: bv64)
+	ensures var res := b & 0x7;
+		0 <= res <= 7
+{}
+
+lemma Shift30LessThan4(b: bv32)
+	ensures var res := b >> 30;
+		0 <= res <= 3
+{}
+
+lemma And3fAtMost64(b: bv8)
+	ensures var res := b & 0x3F;
+		0 <= res < 64
+{}
+
+datatype MetaHdr = MetaHdr(
+	CurrINF: bv8,
+	CurrHF:  bv8,
+	SegLen0: bv8,
+	SegLen1: bv8,
+	SegLen2: bv8
+)
+
+function InBounds(m: MetaHdr): bool {
+	// each of the following conditions is essential for
+	// proving SerializeAndDeserializeLemma
+	0 <= m.CurrINF <= 3  &&
+	0 <= m.CurrHF  <= 63 &&
+	0 <= m.SegLen0 <= 63 &&
+	0 <= m.SegLen1 <= 63 &&
+	0 <= m.SegLen2 <= 63
+}
+
+function Uint32Spec(b0: bv8, b1: bv8, b2: bv8, b3: bv8): bv32 {
+	(b3 as bv32) | ((b2 as bv32)<<8) | ((b1 as bv32)<<16) | ((b0 as bv32)<<24)
+}
+
+function PutUint32Spec(b0: bv8, b1: bv8, b2: bv8, b3: bv8, v: bv32): bool {
+	var mask: bv32 := 0x000000FF;
+	&& b0 == ((v >> 24) & mask) as bv8
+	&& b1 == ((v >> 16) & mask) as bv8
+	&& b2 == ((v >> 8) & mask) as bv8
+	&& b3 == (v & mask) as bv8
+}
+
+function DecodedFrom(line: bv32): MetaHdr {
+	MetaHdr(
+		(line >> 30) as bv8,
+		((line>>24) & 0x3F) as bv8,
+		((line>>12) & 0x3F) as bv8,
+		((line>>6) & 0x3F) as bv8,
+		(line & 0x3F) as bv8
+	)
+}
+
+function SerializedToLine(m: MetaHdr): bv32 {
+	((m.CurrINF as bv32) << 30) |
+	(((m.CurrHF & 0x3F) as bv32)<<24) |
+	(((m.SegLen0 & 0x3F) as bv32) << 12) |
+	(((m.SegLen1 & 0x3F) as bv32) << 6) |
+	((m.SegLen2 & 0x3F) as bv32)
+}
+
+lemma SerializeAndDeserializeLemma(m: MetaHdr, b0: bv8, b1: bv8, b2: bv8, b3: bv8)
+	requires InBounds(m)
+	ensures var line := SerializedToLine(m);
+		PutUint32Spec(b0, b1, b2, b3, line) ==> (DecodedFrom(Uint32Spec(b0, b1, b2, b3)) == m)
+{}
+
+lemma SerializeAndDeserializeMetaHdrLemma(m: MetaHdr)
+	requires InBounds(m)
+	ensures  DecodedFrom(SerializedToLine(m)) == m
+{}
+
+lemma InfoFieldFirstByteSerializationLemmas()
+	// or
+	ensures 0 as bv8 | 1 == 1
+	ensures 0 as bv8 | 2 == 2
+	ensures 1 as bv8 | 2 == 3
+	// and
+	ensures 0 as bv8 & 1 == 0
+	ensures 0 as bv8 & 2 == 0
+	ensures 1 as bv8 & 1 == 1
+	ensures 1 as bv8 & 2 == 0
+	ensures 2 as bv8 & 1 == 0
+	ensures 2 as bv8 & 2 == 2
+	ensures 3 as bv8 & 1 == 1
+	ensures 3 as bv8 & 2 == 2
+{}
+
+
+// Functional specs for encoding/binary (BigEndian)
+function FUint16Spec(b0: bv8, b1: bv8): bv16 {
+	(b1 as bv16) | ((b0 as bv16) << 8)
+}
+
+function FPutUint16Spec(v: bv16): (bv8, bv8) {
+	((v >> 8) as bv8, (v & 0xFF) as bv8)
+}
+
+lemma FUint16AfterFPutUint16(v: bv16)
+	ensures var (b0, b1) := FPutUint16Spec(v);
+		FUint16Spec(b0, b1) == v
+{}
+
+lemma FPutUint16AfterFUint16(b0: bv8, b1: bv8)
+	ensures var v := FUint16Spec(b0, b1);
+		FPutUint16Spec(v) == (b0, b1)
+{}
+
+function FUint32Spec(b0: bv8, b1: bv8, b2: bv8, b3: bv8): bv32 {
+	(b3 as bv32) | ((b2 as bv32) << 8) | ((b1 as bv32) << 16) | ((b0 as bv32) << 24)
+}
+
+function FPutUint32Spec(v: bv32): (bv8, bv8, bv8, bv8) {
+	(((v >> 24) & 0xFF) as bv8,
+	((v >> 16) & 0xFF) as bv8,
+	((v >> 8) & 0xFF) as bv8,
+	(v & 0xFF) as bv8)
+}
+
+lemma FUint32AfterFPutUint32(v: bv32)
+	ensures var (b0, b1, b2, b3) := FPutUint32Spec(v);
+		FUint32Spec(b0, b1, b2, b3) == v
+{}
+
+lemma FPutUint32AfterFUint32(b0: bv8, b1: bv8, b2: bv8, b3: bv8)
+	ensures var v := FUint32Spec(b0, b1, b2, b3);
+		FPutUint32Spec(v) == (b0, b1, b2, b3)
+{}
+
+lemma FoldChecksumLemma(csum: bv32)
+	ensures csum > 0xffff ==>
+		var newCsum := (csum >> 16) + (csum & 0xffff);
+		newCsum < csum
+{}
+

--- a/src/verification/utils/definitions/definitions.gobra
+++ b/src/verification/utils/definitions/definitions.gobra
@@ -96,14 +96,14 @@ func TODO()
 
 ghost
 ensures res == (low <= i && i < high)
-decreases _
+decreases
 pure func InRange(i, low, high int) (res bool) {
 	return low <= i && i < high
 }
 
 ghost
 ensures res == (low <= i && i <= high)
-decreases _
+decreases
 pure func InRangeInc(i, low, high int) (res bool) {
 	return low <= i && i <= high
 }

--- a/src/verification/utils/definitions/definitions.gobra
+++ b/src/verification/utils/definitions/definitions.gobra
@@ -1,0 +1,125 @@
+// Copyright 2022 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +gobra
+
+package definitions
+
+const HalfPerm perm = 1/2
+const (
+	R00 perm = 1/(2 << iota)
+	R0
+	R1
+	R2
+	R3
+	R4
+	R5
+	R6
+	R7
+	R8
+	R9
+	R10
+	R11
+	R12
+	R13
+	R14
+	R15
+	R16
+	R17
+	R18
+	R19
+	R20
+	R21
+	R22
+	R23
+	R24
+	R25
+	R26
+	R27
+	R28
+	R29
+	R30
+	R31
+	R32
+	R33
+	R34
+	R35
+	R36
+	R37
+	R38
+	R39
+	R40
+	R41
+	R42
+	R43
+	R44
+	R45
+	R46
+	R47
+	R48
+	R49
+	R50
+)
+
+ghost
+decreases
+ensures res <= a && res <= b && (res == a || res == b)
+pure func
+MinInt(a, b int) (res int) {
+	return a < b ? a : b;
+}
+
+ghost
+decreases
+pure func
+MaxInt(a, b int) (res int) {
+	return a < b ? a : b;
+}
+
+
+// Kills the branches that reach this point.
+ghost
+ensures false
+decreases _
+func TODO()
+
+ghost
+ensures res == (low <= i && i < high)
+decreases _
+pure func InRange(i, low, high int) (res bool) {
+	return low <= i && i < high
+}
+
+ghost
+ensures res == (low <= i && i <= high)
+decreases _
+pure func InRangeInc(i, low, high int) (res bool) {
+	return low <= i && i <= high
+}
+
+ghost
+requires 0 <= low && low <= high && high <= len(s)
+ensures forall i int :: {&s[low:high][i]} 0 <= i && i < len(s[low:high]) ==> &s[low:high][i] == &s[i+low]
+decreases
+func SubSliceOverlaps(s []byte, low, high int) {
+
+}
+
+ghost
+requires 0 <= start && start <= end && end <= len(a)
+requires a[start:end] === b
+ensures forall i int :: { &a[i] }{ &b[i] } InRange(i, start, end) ==> &a[i] == &b[i - start]
+decreases
+func lemmaSliceGhostEquals(a, b []byte, start, end int) {
+}

--- a/src/verification/utils/definitions/definitions_test.gobra
+++ b/src/verification/utils/definitions/definitions_test.gobra
@@ -1,0 +1,7 @@
+
+package definitions
+
+func test() {
+	assert R00 < writePerm
+	assert R0 < R00
+}

--- a/src/verification/utils/seqs/seqs.gobra
+++ b/src/verification/utils/seqs/seqs.gobra
@@ -1,0 +1,58 @@
+// Copyright 2022-2023 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +gobra
+
+package seqs
+
+import sl "verification/utils/slices"
+
+ghost
+pure
+requires 0 <= n
+ensures  len(res) == n
+ensures  forall i int :: { res[i] } 0 <= i && i < len(res) ==> !res[i]
+decreases _
+func NewSeqBool(n int) (res seq[bool])
+
+ghost
+requires size >= 0
+ensures len(res) == size
+ensures forall i int :: { res[i] } 0 <= i && i < size ==> res[i] == byte(0)
+decreases _
+pure func NewSeqByte(size int) (res seq[byte])
+
+ghost
+requires size >= 0
+ensures len(res) == size
+ensures forall i int :: { res[i] } 0 <= i && i < size ==> res[i] == nil
+decreases _
+pure func NewSeqByteSlice(size int) (res seq[[]byte])
+
+ghost
+requires acc(sl.Bytes(ub, 0, len(ub)), _)
+ensures len(res) == len(ub)
+ensures forall i int :: { res[i] } 0 <= i && i < len(ub) ==>
+    res[i] == sl.GetByte(ub, 0, len(ub), i)
+decreases _
+pure func ToSeqByte(ub []byte) (res seq[byte])
+
+
+// returns a new sequence, where each element is trimmed by n elements, from the end
+ghost
+opaque
+decreases _
+pure func TrimEachSuffix_byte(s seq[seq[byte]], n int) seq[seq[byte]] {
+	return len(s) == 0 ? seq[seq[byte]]{} : ( TrimEachSuffix_byte(s[:len(s) - 1], n) ++ (seq[seq[byte]]{ s[0][:len(s) - n] }) )
+}

--- a/src/verification/utils/sets/sets.gobra
+++ b/src/verification/utils/sets/sets.gobra
@@ -1,0 +1,12 @@
+// +gobra
+
+package sets
+
+ghost
+requires start <= end
+ensures len(res) == end - start
+ensures forall i int :: {i in res} (i in res) == (start <= i && i < end)
+decreases end - start
+pure func RangeInt(start, end int) (res set[int]) {
+	return start == end ? set[int]{} : set[int]{start} union RangeInt(start + 1, end)
+}

--- a/src/verification/utils/slices/slices.gobra
+++ b/src/verification/utils/slices/slices.gobra
@@ -1,0 +1,221 @@
+// Copyright 2022 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +gobra
+
+package slices
+
+// How to extend this file:
+// - if we need to support slices of non-supported types, we must repeat all definitions
+//   for that type. For this, we should be careful to avoid introducing cylical dependencies.
+//   The suffix of the predicate/function should be the type of the elems of the slices.
+// - For each type, there might be two different types of operations: those that keep track
+//   of contents (the name of the operation ends in "C"), and those who do not.
+
+pred Bytes(s []byte, start int, end int) {
+	// start inclusive
+	0 <= start &&
+	start <= end &&
+	// end exclusive
+	end <= cap(s) &&
+	forall i int :: { &s[i] } start <= i && i < end ==> acc(&s[i])
+}
+
+pred Runes(s []rune, start int, end int) {
+	// start inclusive
+	0 <= start &&
+	start <= end &&
+	// end exclusive
+	end <= cap(s) &&
+	forall i int :: { &s[i] } start <= i && i < end ==> acc(&s[i])
+}
+
+pure
+requires acc(Bytes(s, start, end), _)
+requires start <= i && i < end
+decreases
+func GetByte(s []byte, start int, end int, i int) byte {
+	return unfolding acc(Bytes(s, start, end), _) in s[i]
+}
+
+pure
+requires acc(Runes(s, start, end), _)
+requires start <= i && i < end
+decreases
+func GetRune(s []rune, start int, end int, i int) rune {
+	return unfolding acc(Runes(s, start, end), _) in s[i]
+}
+
+
+ghost
+requires acc(Runes(ub, 0, len(ub)), _)
+ensures len(res) == len(ub)
+ensures forall i int :: { res[i] } 0 <= i && i < len(ub) ==>
+    res[i] == GetRune(ub, 0, len(ub), i)
+decreases _
+pure func ViewRunes(ub []rune) (res seq[rune])
+
+ghost
+requires 0 < p
+requires acc(Bytes(s, start, end), p)
+requires start <= idx && idx <= end
+ensures  acc(Bytes(s, start, idx), p)
+ensures  acc(Bytes(s, idx, end), p)
+decreases
+func SplitByIndex_Bytes(s []byte, start int, end int, idx int, p perm) {
+	unfold acc(Bytes(s, start, end), p)
+	fold   acc(Bytes(s, start, idx), p)
+	fold   acc(Bytes(s, idx, end), p)
+}
+
+ghost
+requires 0 < p
+requires acc(Bytes(s, start, idx), p)
+requires acc(Bytes(s, idx,   end), p)
+ensures  acc(Bytes(s, start, end), p)
+decreases
+func CombineAtIndex_Bytes(s []byte, start int, end int, idx int, p perm) {
+	unfold acc(Bytes(s, start, idx), p)
+	unfold acc(Bytes(s, idx,   end), p)
+	fold   acc(Bytes(s, start, end), p)
+}
+
+ghost
+requires 0 < p
+requires acc(Bytes(s, start, end), p)
+// the following precondition convinces Gobra that
+// the slice operation is well-formed
+requires unfolding acc(Bytes(s, start, end), p) in true
+ensures  acc(Bytes(s[start:end], 0, len(s[start:end])), p)
+decreases
+func Reslice_Bytes(s []byte, start int, end int, p perm) {
+	unfold acc(Bytes(s, start, end), p)
+	assert forall i int :: { &s[start:end][i] }{ &s[start + i] } 0 <= i && i < (end-start) ==> &s[start:end][i] == &s[start + i]
+	fold  acc(Bytes(s[start:end], 0, len(s[start:end])), p)
+}
+
+ghost
+requires 0 < p
+requires 0 <= start && start <= end && end <= cap(s)
+requires len(s[start:end]) <= cap(s)
+requires acc(Bytes(s[start:end], 0, len(s[start:end])), p)
+ensures  acc(Bytes(s, start, end), p)
+decreases
+func Unslice_Bytes(s []byte, start int, end int, p perm) {
+	unfold acc(Bytes(s[start:end], 0, len(s[start:end])), p)
+	assert 0 <= start && start <= end && end <= cap(s)
+	assert forall i int :: { &s[start:end][i] } 0 <= i && i < len(s[start:end]) ==> acc(&s[start:end][i], p)
+	assert forall i int :: { &s[start:end][i] }{ &s[start + i] } 0 <= i && i < len(s[start:end]) ==> &s[start:end][i] == &s[start + i]
+
+	invariant 0 <= j && j <= len(s[start:end])
+	invariant forall i int :: { &s[start:end][i] } j <= i && i < len(s[start:end]) ==> acc(&s[start:end][i], p)
+	invariant forall i int :: { &s[start:end][i] }{ &s[start + i] } 0 <= i && i < len(s[start:end]) ==> &s[start:end][i] == &s[start + i]
+	invariant forall i int :: { &s[i] } start <= i && i < start+j ==> acc(&s[i], p)
+	decreases len(s[start:end]) - j
+	for j := 0; j < len(s[start:end]); j++ {
+		assert forall i int :: { &s[i] } start <= i && i < start+j ==> acc(&s[i], p)
+		assert &s[start:end][j] == &s[start + j]
+		assert acc(&s[start + j], p)
+		assert forall i int :: { &s[i] } start <= i && i <= start+j ==> acc(&s[i], p)
+	}
+	fold acc(Bytes(s, start, end), p)
+}
+
+ghost
+requires 0 < p
+requires 0 <= start && start <= end && end <= len(s)
+requires acc(Bytes(s, 0, len(s)), p)
+ensures  acc(Bytes(s[start:end], 0, end-start), p)
+ensures  acc(Bytes(s, 0, start), p)
+ensures  acc(Bytes(s, end, len(s)), p)
+decreases
+func SplitRange_Bytes(s []byte, start int, end int, p perm) {
+	SplitByIndex_Bytes(s, 0, len(s), start, p)
+	SplitByIndex_Bytes(s, start, len(s), end, p)
+	Reslice_Bytes(s, start, end, p)
+}
+
+ghost
+requires 0 < p
+requires 0 <= start && start <= end && end <= len(s)
+requires acc(Bytes(s[start:end], 0, end-start), p)
+requires acc(Bytes(s, 0, start), p)
+requires acc(Bytes(s, end, len(s)), p)
+ensures  acc(Bytes(s, 0, len(s)), p)
+decreases
+func CombineRange_Bytes(s []byte, start int, end int, p perm) {
+	Unslice_Bytes(s, start, end, p)
+	CombineAtIndex_Bytes(s, start, len(s), end, p)
+	CombineAtIndex_Bytes(s, 0, len(s), start, p)
+}
+
+ghost
+ensures Bytes(nil, 0, 0)
+decreases
+func NilAcc_Bytes() {
+	fold Bytes(nil, 0, 0)
+}
+
+ghost
+requires  len(s1) > 0 || len(s2) > 0
+preserves Bytes(s1, 0, len(s1))
+preserves acc(Bytes(s2, 0, len(s2)), _)
+ensures   s1 !== s2
+decreases
+func PermsImplyIneqWithWildcard(s1 []byte, s2 []byte) {
+	unfold Bytes(s1, 0, len(s1))
+	unfold acc(Bytes(s2, 0, len(s2)), _)
+	if len(s1) > 0 && len(s2) > 0 {
+		// This assertion checks that the memory addresses of the first elements
+		// in s1 and s2 are different. By doing so, we instantiate the triggers in
+		// the quantifier bodies to prove the required inequality for non-empty slices.
+		assert &s1[0] != &s2[0]
+	}
+	fold Bytes(s1, 0, len(s1))
+	fold acc(Bytes(s2, 0, len(s2)), _)
+}
+
+ghost
+requires  0 < p
+requires  len(s1) > 0 || len(s2) > 0
+preserves Bytes(s1, 0, len(s1))
+preserves acc(Bytes(s2, 0, len(s2)), p)
+ensures   s1 !== s2
+decreases
+func PermsImplyIneq(s1 []byte, s2 []byte, p perm) {
+	unfold Bytes(s1, 0, len(s1))
+	unfold acc(Bytes(s2, 0, len(s2)), p)
+	if len(s1) > 0 && len(s2) > 0 {
+		// This assertion checks that the memory addresses of the first elements
+		// in s1 and s2 are different. By doing so, we instantiate the triggers in
+		// the quantifier bodies to prove the required inequality for non-empty slices.
+		assert &s1[0] != &s2[0]
+	}
+	fold Bytes(s1, 0, len(s1))
+	fold acc(Bytes(s2, 0, len(s2)), p)
+}
+
+/** Auxiliar definitions Any **/
+ghost
+requires size >= 0
+ensures len(res) == size
+ensures forall i int :: { res[i] } 0 <= i && i < size ==> res[i] == nil
+decreases _
+pure func NewSeq_Any(size int) (res seq[any])
+
+// TODO:
+// func ToSeq_Any
+// ResliceC_Any
+
+/** End of Auxiliar definitions Any **/


### PR DESCRIPTION
In this PR, we verify the following functions of the `path` package:
- `path.Clean`
- `path.Split`

In order to verify this package, we switched out every occurrence of `string` with `string_byte` which is an alias for `[]byte`. This is because Gobra does not yet support strings.

The main part of the work is on `path.Clean`, which is verified for safety and correctness. We verify that `Clean` adheres to the functional specification `SpecClean`

### Open questions

In `path_spec`, there currently are two unverified functions ("axioms"), both marked as trusted and provided without body:
- `axiomStringByteAcc`: An assumption that it is always fine to restore full permissions to the string. This is not the biggest problem since the original source uses immutable strings anyways but before finalizing this, we should try to get rid of this assumption.
- `axiomEqualGhostEqualPath`:  the assumption that for our `Path` struct, if `a == b` then `a === b`